### PR TITLE
Add Setup team-owned settings to the ADMX and ADML

### DIFF
--- a/Visual Studio IDE/VisualStudio.admx
+++ b/Visual Studio IDE/VisualStudio.admx
@@ -33,9 +33,9 @@
                     <reference ref="VisualStudio2022"/>
                 </and>
             </definition>
-            <definition name="VisualStudio2022_4_AndHigher" displayName="$(string.VisualStudio2022_4)">
+            <definition name="VisualStudio2022AndHigher" displayName="$(string.VisualStudio2022)">
                 <and>
-                    <reference ref="VisualStudio2022_4"/>
+                    <reference ref="VisualStudio2022"/>
                 </and>
             </definition>
         </definitions>
@@ -99,7 +99,7 @@
             key="SOFTWARE\Policies\Microsoft\VisualStudio\Setup" 
             valueName="RemoveOos">
             <parentCategory ref="InstallandUpdateSettings" />
-            <supportedOn ref="VisualStudio2022_4_AndHigher" />
+            <supportedOn ref="VisualStudio2022AndHigher" />
             <enabledValue>
                 <decimal value="1" />
             </enabledValue>

--- a/Visual Studio IDE/en-US/VisualStudio.adml
+++ b/Visual Studio IDE/en-US/VisualStudio.adml
@@ -26,11 +26,11 @@
       <string id="VisualStudioProductName2022_4">Visual Studio 2022, 17.4</string>
 
       <!-- Convey a particular version and higher. -->
-      <string id="VisualStudio2017">At least Visual Studio 2017</string>
-      <string id="VisualStudio2019">At least Visual Studio 2019</string>
-      <string id="VisualStudio2022">At least Visual Studio 2022</string>
-      <string id="VisualStudio2022_1">At least Visual Studio 2022, 17.1</string>
-      <string id="VisualStudio2022_4">At least Visual Studio 2022, 17.4</string>
+      <string id="VisualStudio2017">Visual Studio 2017 and higher.</string>
+      <string id="VisualStudio2019">Visual Studio 2019 and higher.</string>
+      <string id="VisualStudio2022">Visual Studio 2022 and higher.</string>
+      <string id="VisualStudio2022_1">Visual Studio 2022, 17.1 and higher.</string>
+      <string id="VisualStudio2022_4">Visual Studio 2022, 17.4 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->
       <string id="VisualStudio2022_Enterprise_Professional">At least Visual Studio 2022, Enterprise and Professional only</string>
@@ -112,10 +112,10 @@ If AdministratorUpdatesEnabled is disabled but AdministratorUpdatesOptOut is not
 
       <!-- LiveShare Presentations -->
       <presentation id="LiveShare_DomainName_PresentationId">
-			  <textBox refId="LiveShare_DomainName_TextBox">
-			    <label>Enter Domain Name:</label>
-			  </textBox>
-	  </presentation>
+      <textBox refId="LiveShare_DomainName_TextBox">
+        <label>Enter Domain Name:</label>
+        </textBox>
+    </presentation>
     </presentationTable>
 </resources>
 </policyDefinitionResources>


### PR DESCRIPTION
## What

1. Add policies to the Visual Studio Group Policy administrative templates (ADMX) for the Setup and LiveShare teams.
2. Refactor supporedOn definitions to convey which product versions are supported by what policies.
3. Refactor both the .admx and .adml for readability, and ease of adding future policies.

## Why

1. To be discoverable by Admins, some, but not all, Setup-owned policies need to be included in the Visual Studio Group policy admin template.  
2. The current 'supportedOn' design made adding additional version of VS tenuous.  Instead, I took a page from the Windows.admx ( C:\Windows\PolicyDefinitions\Windows.admx)
3. To prepare for additional teams adding their policies, I wanted to ensure that the current files and policies were easy to read and easy to add to.

## How
1. Removed policies that should not be discoverable by Admins and added policies that should be discoverable.
4. Refactored supportedOn definitions to be more like Windows and to be more easily forward manageable.
5. Refactored files by categorizing policies alphabetically by team and added comments to make future development easier.

## Testing
[X] Manual testing by opening Group Policy Editor