### PR TITLE
Update logic to overwrite files when installing admx

### DIFF
--- a/src/ADMXExtractor/View/MainWindow.xaml.cs
+++ b/src/ADMXExtractor/View/MainWindow.xaml.cs
@@ -120,7 +120,7 @@ namespace ADMXExtractor
             foreach (FileInfo file in dir.GetFiles())
             {
                 string targetFilePath = Path.Combine(destinationDir, file.Name);
-                file.CopyTo(targetFilePath);
+                file.CopyTo(targetFilePath, overwrite: true);
             }
 
             // If recursive and copying subdirectories, recursively call this method


### PR DESCRIPTION
### What
Update default behavior to overwrite .admx files when installing.

### Why
Currently, if a user wants to install the newest ADMX files, installation fails because the files cannot be overwritten.

### How
Set overwrite to true.