### PR TITLE
Small Bug Fixes

### DIFF
--- a/build/PrepareStagingDirectoryForSelfExtractor.ps1
+++ b/build/PrepareStagingDirectoryForSelfExtractor.ps1
@@ -41,7 +41,7 @@ $admxExtractorlanguageTable = [ordered]@{
     JPN="ja";
     KOR="ko";
     PLK="pl";
-    PTB="pt";
+    PTB="pt-BR";
     RUS="ru";
     TRK="tr";
 }

--- a/src/ADMXExtractor/View/MainWindow.xaml
+++ b/src/ADMXExtractor/View/MainWindow.xaml
@@ -25,7 +25,8 @@
         <TextBlock x:Name="LicenseTermsTitle" 
                    Grid.Row="0" 
                    Padding="20,20,20,0"
-                   VerticalAlignment="Center" />
+                   VerticalAlignment="Center"
+                   TextWrapping="Wrap" />
         <ScrollViewer Grid.Row="1" 
                       Padding="0, 20, 0, 0"
                       BorderBrush="White"


### PR DESCRIPTION
## What
- Update the language folder consumed by the ADMXExtractor for Portuguese to "pt-BR."
- Add text wrapping to the License title to fix an issue with the Russian language running off the screen.
![admxExtractor_Russian_Padding_test_fail](https://user-images.githubusercontent.com/5585130/194771672-f111ef34-c146-4ab7-aca1-c387697b46cc.png)

## Why
- The app is currently not localized in Portuguese Brazil.
- The title in Russian runs off the page.

## How
- Update the folder name from pt to pt-BR
- Add Text wrapping
