### PR TITLE
Added text block to checkbox to allow text wrapping.

### DIFF
--- a/src/ADMXExtractor/View/MainWindow.xaml
+++ b/src/ADMXExtractor/View/MainWindow.xaml
@@ -42,14 +42,13 @@
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="auto" />
             </Grid.ColumnDefinitions>
-            <CheckBox x:Name="LicenseTermsCheckBox" 
-                      Grid.Column="0" 
+            <CheckBox Grid.Column="0" 
                       Checked="LicenseTermsCheckBox_Checked"
                       Unchecked="LicenseTermsCheckBox_Unchecked"
-                      VerticalAlignment="Center">
-                <Border 
-                    CornerRadius="0"
-                    BorderThickness="1" />
+                      VerticalAlignment="Center"
+                      BorderThickness="1">
+                <TextBlock x:Name="LicenseTermsCheckBoxTextBlock"
+                           TextWrapping="Wrap" />
             </CheckBox>
             <Button x:Name="LicenseTermsContinueButton"
                     Grid.Column="1"

--- a/src/ADMXExtractor/View/MainWindow.xaml.cs
+++ b/src/ADMXExtractor/View/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace ADMXExtractor
             Title = NonLocalizableWindowTitle;
             LicenseTermsTitle.Text = Strings.LicenseTermsTitle;
             LicenseTerms.Text = Strings.LicenseTermsText;
-            LicenseTermsCheckBox.Content = Strings.LicenseTermsCheckBoxText;
+            LicenseTermsCheckBoxTextBlock.Text = Strings.LicenseTermsCheckBoxText;
             LicenseTermsContinueButton.Content = Strings.LicenseTermsContinueButtonText;
             LicenseTermsContinueButton.IsEnabled = false;
 


### PR DESCRIPTION
## What
Enable text wrapping in the License view checkbox.

## Why
In Russian, the text was running into the button.
![russian_after](https://user-images.githubusercontent.com/5585130/194773592-6c7d297b-9ac7-44ab-b969-9558186bf4c1.png)

## How
Add a text block and enable wrapping.

## Screenshots of Fix
![admx_Russian](https://user-images.githubusercontent.com/5585130/194773930-6b0ec21c-c334-45bf-84f1-a58b6a1d94d8.png)
