### PR TITLE
Update dialog to account for 'cancel' and 'abort.'

### DIFF
--- a/src/ADMXExtractor/Strings.Designer.cs
+++ b/src/ADMXExtractor/Strings.Designer.cs
@@ -70,6 +70,15 @@ namespace ADMXExtractor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File extraction was cancelled..
+        /// </summary>
+        internal static string FileExtractionCancel {
+            get {
+                return ResourceManager.GetString("FileExtractionCancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to extract files. {0}.
         /// </summary>
         internal static string FileExtractionFailure {

--- a/src/ADMXExtractor/Strings.resx
+++ b/src/ADMXExtractor/Strings.resx
@@ -120,6 +120,9 @@
   <data name="BrowseForFolderDescriptionText" xml:space="preserve">
     <value>Select a folder to store the extracted files</value>
   </data>
+  <data name="FileExtractionCancel" xml:space="preserve">
+    <value>File extraction was cancelled.</value>
+  </data>
   <data name="FileExtractionFailure" xml:space="preserve">
     <value>Failed to extract files. {0}</value>
     <comment>{0} The exception message</comment>

--- a/src/ADMXExtractor/View/MainWindow.xaml.cs
+++ b/src/ADMXExtractor/View/MainWindow.xaml.cs
@@ -64,35 +64,38 @@ namespace ADMXExtractor
             browseForFolder.SelectedPath = Directory.Exists(policyDefinitionPath) ? policyDefinitionPath : winDirPath;
 
             browseForFolder.Description = Strings.BrowseForFolderDescriptionText;
-
-            var dialogResult = browseForFolder.ShowDialog();
-            if (!dialogResult.Equals(System.Windows.Forms.DialogResult.OK))
-            {
-                // If the user closes the FolderBrowserDialog by clicking "Cancel" or by clicking the "X" in the upper right corner,
-                // exit the application.
-                Close();
-            }
-
-            // Extract the ADMX and ADSM files to the selected directory.
-            var source = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AdmxDirectoryName);
-            var selected = browseForFolder.SelectedPath;
-
+            
             string messageBoxText;
             MessageBoxImage messageBoxImage;
-            try
+            
+            var dialogResult = browseForFolder.ShowDialog();
+            if (dialogResult.Equals(System.Windows.Forms.DialogResult.Cancel) || dialogResult.Equals(System.Windows.Forms.DialogResult.Abort))
             {
-                CopyFiles(source, selected);
-                messageBoxText = Strings.FileExtractionSuccess;
+                // If the user closes or aborts the FolderBrowserDialog by clicking "Cancel" or by clicking the "X" in the upper right corner,
+                // exit the application.
+                messageBoxText = string.Format(Strings.FileExtractionCancel);
                 messageBoxImage = (MessageBoxImage)MessageBoxIcon.Information;
             }
-            catch (Exception ex)
+            else
             {
-                messageBoxText = string.Format(Strings.FileExtractionFailure, ex.Message);
-                messageBoxImage = (MessageBoxImage)MessageBoxIcon.Warning;
-            }
-            
-            System.Windows.MessageBox.Show(messageBoxText, NonLocalizableWindowTitle, MessageBoxButton.OK, messageBoxImage, MessageBoxResult.OK);
+                // Extract the ADMX and ADSM files to the selected directory.
+                var source = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, AdmxDirectoryName);
+                var selected = browseForFolder.SelectedPath;
 
+                try
+                {
+                    CopyFiles(source, selected);
+                    messageBoxText = Strings.FileExtractionSuccess;
+                    messageBoxImage = (MessageBoxImage)MessageBoxIcon.Information;
+                }
+                catch (Exception ex)
+                {
+                    messageBoxText = string.Format(Strings.FileExtractionFailure, ex.Message);
+                    messageBoxImage = (MessageBoxImage)MessageBoxIcon.Warning;
+                }
+            }
+
+            System.Windows.MessageBox.Show(messageBoxText, NonLocalizableWindowTitle, MessageBoxButton.OK, messageBoxImage, MessageBoxResult.OK);
             Close();
         }
 


### PR DESCRIPTION
## What
Update the logic and final dialog to display a message if the user cancels or aborts the operation.

## Why
Currently, there is no cancel logic.  The files are simply copied whether the user cancels or not.

## How
Check if the dialog result is cancel or abort and handle appropriately.