### PR TITLE
Missing closing string token in VisualStudio.adml

### DIFF
--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -82,7 +82,7 @@ If set to 2, then administrator updates delivered through either WSUS/SCCM or In
 
 If set to 0 or missing entirely, then administrator updates will not be available to the machine.        
         
-For more information, see https://aka.ms/EnableAdminUpdates.
+For more information, see https://aka.ms/EnableAdminUpdates.</string>
 
       <string id="AdministratorUpdatesEnabled_EnabledForCatalogAndWSUS">Administrator Updates Enabled for Catalog and WSUS</string>
       <string id="AdministratorUpdatesEnabled_EnabledForCatalogWSUSAndMU">Administrator Updates Enabled for Catalog, WSUS and Microsoft Updates</string>


### PR DESCRIPTION
## What
Fixed issue in VisualStudio.adml where a string element was not closed properly.

## Why
This issue was causing the Microbuild Parser to fail.

## How
Searched document for missing </string> and added it.