### PR TITLE
Add compliance yml

### DIFF
--- a/Tests/VsAdmxTests/UnitTests/UnitTests.cs
+++ b/Tests/VsAdmxTests/UnitTests/UnitTests.cs
@@ -16,21 +16,21 @@ namespace UnitTests
         [TestMethod]
         public void CheckAdmxFileExists()
         {
-            string admxFullFilePath = Path.Join(ADMX_FILE_PATH, ADMX_FILE_NAME);
+            string admxFullFilePath = Path.Combine(ADMX_FILE_PATH, ADMX_FILE_NAME);
             Assert.IsTrue(File.Exists(admxFullFilePath));
         }
 
         [TestMethod]
         public void CheckAdmlFileExists()
         {
-            string admlFullFilePath = Path.Join(ADML_FILE_PATH, ADML_FILE_NAME);
+            string admlFullFilePath = Path.Combine(ADML_FILE_PATH, ADML_FILE_NAME);
             Assert.IsTrue(File.Exists(admlFullFilePath));
         }
 
         [TestMethod]
         public void CheckAdmxXml()
         {
-            string admxFullFilePath = Path.Join(ADMX_FILE_PATH, ADMX_FILE_NAME);
+            string admxFullFilePath = Path.Combine(ADMX_FILE_PATH, ADMX_FILE_NAME);
 
             try
             {
@@ -49,7 +49,7 @@ namespace UnitTests
         [TestMethod]
         public void CheckAdmlXml()
         {
-            string admlFullFilePath = Path.Join(ADML_FILE_PATH, ADML_FILE_NAME);
+            string admlFullFilePath = Path.Combine(ADML_FILE_PATH, ADML_FILE_NAME);
 
             try
             {

--- a/Tests/VsAdmxTests/UnitTests/UnitTests.csproj
+++ b/Tests/VsAdmxTests/UnitTests/UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <Nullable>enable</Nullable>
-
+	<LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Tests/VsAdmxTests/UnitTests/UnitTests.csproj
+++ b/Tests/VsAdmxTests/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/build.yml
+++ b/build.yml
@@ -15,6 +15,14 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk matching global.json'
+  inputs:
+    packageType: sdk
+    useGlobalJson: true
+    workingDirectory: $(Build.SourcesDirectory)
+    performMultiLevelLookup: true
+
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2

--- a/compliance.yml
+++ b/compliance.yml
@@ -1,6 +1,3 @@
-trigger:
-- 'main'
-
 pool: VSEngSS-MicroBuild2022-1ES
 
 parameters:
@@ -18,18 +15,40 @@ parameters:
   default: Release
   values:
   - Release
+- name: BinSkimSeverity
+  displayName: BinSkim severity
+  type: string
+  default: Error
+  values:
+  - Error
+  - Note
+  - Warning
 
 variables:
   CodeQL.Enabled: true
 
 schedules:
-- cron: '0 0 */28 * *'
-  displayName: 'Run every 28 days at 12:00 a.m.'
+- cron: '0 0 */21 * *'
+  displayName: 'Run every 21 days at 12:00 a.m.'
   branches:
-    include: main
+    include: 
+    - main
 
 steps:
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk matching global.json'
+  inputs:
+    packageType: sdk
+    useGlobalJson: true
+    workingDirectory: $(Build.SourcesDirectory)
+    performMultiLevelLookup: true
+
 - task: CodeQL3000Init@0
+
+- task: NuGetToolInstaller@1
+  displayName: Install NuGet
+  inputs:
+    versionSpec: '6.x'
 
 - task: NuGetCommand@2
   inputs:
@@ -37,9 +56,47 @@ steps:
 
 - task: VSBuild@1
   inputs:
-    solution: '*.sln'
+    solution: '**/*.sln'
     maximumCpuCount: true
     platform: '${{ parameters.BuildPlatform }}'
     configuration: '${{ parameters.BuildConfiguration }}'
 
 - task: CodeQL3000Finalize@0
+
+- task: PoliCheck@2
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    targetArgument: '$(Build.SourcesDirectory)'
+    optionsFC: 0
+    optionsXS: 1
+    optionsHMENABLE: 0
+  continueOnError: true
+
+- task: CredScan@3
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
+    toolMajorVersion: V2
+
+- task: BinSkim@4
+  displayName: 'Run BinSkim'
+  inputs:
+    InputType: Basic
+    Function: analyze
+    TargetPattern: guardianGlob
+    AnalyzeTargetGlob: $(Build.SourcesDirectory)/**.dll;$(Build.SourcesDirectory)/**.exe;
+    AnalyzeSymPath: 'Srv*http://msdl.microsoft.com/download/symbols'
+    AnalyzeLocalSymbolDirectories: $(Build.SourcesDirectory)
+    AnalyzeVerbose: true
+    AnalyzeHashes: true
+  continueOnError: true
+
+- task: PublishSecurityAnalysisLogs@3
+  displayName: 'Publish Security Analysis Logs'
+
+- task: PostAnalysis@2
+  displayName: 'Check SDL results'
+  inputs:
+    AllTools: true
+    GdnBreakGdnToolBinSkimSeverity: '${{ parameters.BinSkimSeverity }}'

--- a/compliance.yml
+++ b/compliance.yml
@@ -1,19 +1,45 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 trigger:
-- main
+- 'main'
 
-pool:
-  vmImage: ubuntu-latest
+pool: VSEngSS-MicroBuild2022-1ES
+
+parameters:
+- name: BuildPlatform
+  displayName: Build platform
+  type: string
+  default: 'Any CPU'
+  values:
+  - 'Any CPU'
+  - 'x86'
+  - 'x64'
+- name: BuildConfiguration
+  displayName: Build configuration
+  type: string
+  default: Release
+  values:
+  - Release
+
+variables:
+  CodeQL.Enabled: true
+
+schedules:
+- cron: '0 0 */28 * *'
+  displayName: 'Run every 28 days at 12:00 a.m.'
+  branches:
+    include: main
 
 steps:
-- script: echo Hello, world!
-  displayName: 'Run a one-line script'
+- task: CodeQL3000Init@0
 
-- script: |
-    echo Add other tasks to build, test, and deploy your project.
-    echo See https://aka.ms/yaml
-  displayName: 'Run a multi-line script'
+- task: NuGetCommand@2
+  inputs:
+    command: 'restore'
+
+- task: VSBuild@1
+  inputs:
+    solution: '*.sln'
+    maximumCpuCount: true
+    platform: '${{ parameters.BuildPlatform }}'
+    configuration: '${{ parameters.BuildConfiguration }}'
+
+- task: CodeQL3000Finalize@0


### PR DESCRIPTION
Adding compliance.yml to meet SLA standards. This will run every 21 days, the tasks are same as yaml in AcquisitionExtension except this one needed dotnet sdk.

Latest pipeline run: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7872484&view=results

The unit tests are edited because we updated framework to net472 instead of net 6.0 because of package signature expiration