### PR TITLE
Add AllowStandardUserControl to ADMX

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -285,6 +285,36 @@
                 <decimal value="0"/>
             </disabledValue>
         </policy>
+        <policy 
+            name="AllowStandardUserControl" 
+            class="Machine" 
+            displayName="$(string.AllowStandardUserControl_DisplayName)" 
+            explainText="$(string.AllowStandardUserControl_Explain)" 
+            key="Software\Policies\Microsoft\VisualStudio\Setup" 
+            presentation="$(presentation.AllowStandardUserControl_PresentationId)"
+            valueName="AllowStandardUserControl">
+            <parentCategory ref="InstallandUpdateSettings"/>
+            <supportedOn ref="VisualStudio2017AndHigher"/>
+            <elements>
+                <enum id="AllowStandardUserControlDropID" valueName="AllowStandardUserControl">
+                    <item displayName="$(string.AllowStandardUserControl_Blocked)">
+                        <value>
+                            <decimal value="0" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.AllowStandardUserControl_EnabledForUpdateAndRollback)">
+                        <value>
+                            <decimal value="1" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.AllowStandardUserControl_EnabledForAll)">
+                        <value>
+                            <decimal value="2" />
+                        </value>
+                    </item>
+                </enum>
+            </elements>
+        </policy>
 
         <!-- LiveShare Settings -->
         <policy 

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -120,6 +120,21 @@ If set to 0 (disabled) or missing entirely, users will be able to see the Availa
 This functionality requires the Visual Studio 2022 version 17.6 installer to be installed on the client machine.
 
 For more information, see https://aka.ms/vs/setup/policies.</string>
+
+      <string id="AllowStandardUserControl_DisplayName">Allow standard users to execute installer operations</string>
+      <string id="AllowStandardUserControl_Explain">Allows users without administrator permissions to manage their Visual Studio installations. 
+        
+If set to 0 (blocked) or missing entirely, the installer will prompt for administrator permissions using UAC.        
+
+If set to 1 (enabled for Update and Rollback), users without administrator permissions can update or rollback without UAC. All other operations will ask for administrator permissions through UAC.  
+        
+If set to 2 (enabled for all installer operations), users without administrator permissions can fully manage Visual Studio through the Visual Studio Installer without UAC.
+        
+For more information, see http://aka.ms/vs/setup/policies.</string>
+
+      <string id="AllowStandardUserControl_Blocked">Blocked</string>
+      <string id="AllowStandardUserControl_EnabledForUpdateAndRollback">Enabled for Update and Rollback</string>
+      <string id="AllowStandardUserControl_EnabledForAll">Enabled for all installer operations</string>
       
       <!-- LiveShare -->
       <string id="LiveShare_DomainName_DisplayName">Allow only company domain accounts</string>
@@ -172,6 +187,9 @@ For more information, see: https://aka.ms/vsls-policies</string>
         <textBox refId="UpdateConfigurationFile_TextBox">
           <label>Custom Path to the Update Config</label>
         </textBox>
+      </presentation>
+      <presentation id="AllowStandardUserControl_PresentationId">
+         <dropdownList refId="AllowStandardUserControlDropID" noSort="true" defaultItem="0" />
       </presentation>
 
       <!-- LiveShare Presentations -->


### PR DESCRIPTION
# What
Add policy keys for the AllowStandardUserControl to the Visual Studio Install and Update policies

# Why
Visual Studio will be shipping a new feature with new policy to control what operations a standard user may execute

# How
- Add the policy section to the admx file
- Add the resources to the adml file

# Screenshots
![image](https://github.com/microsoft/Visual-Studio-Administrative-Templates/assets/40210514/ed059437-78e1-4c3f-a1e1-d719b5dff294)
![image](https://github.com/microsoft/Visual-Studio-Administrative-Templates/assets/40210514/8f2a5a06-7be3-4232-b9bd-c4bf5b09a873)
