### PR TITLE
Update the definition displayNames for the supportedOn property child nodes

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -20,20 +20,20 @@
             </product>
         </products>
         <definitions>
-            <definition name="VisualStudio2019AndHigher" displayName="$(string.VisualStudio2019)">
+            <definition name="VisualStudio2019AndHigher" displayName="$(string.VisualStudio2019AndHigher)">
                 <and>
                     <reference ref="VisualStudio2019"/>
                     <reference ref="VisualStudio2022"/>
                 </and>
             </definition>
-            <definition name="VisualStudio2017AndHigher" displayName="$(string.VisualStudio2017)">
+            <definition name="VisualStudio2017AndHigher" displayName="$(string.VisualStudio2017AndHigher)">
                 <and>
                     <reference ref="VisualStudio2017"/>
                     <reference ref="VisualStudio2019"/>
                     <reference ref="VisualStudio2022"/>
                 </and>
             </definition>
-            <definition name="VisualStudio2022AndHigher" displayName="$(string.VisualStudio2022)">
+            <definition name="VisualStudio2022AndHigher" displayName="$(string.VisualStudio2022AndHigher)">
                 <and>
                     <reference ref="VisualStudio2022"/>
                 </and>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -27,9 +27,9 @@
       <string id="VisualStudioProductName2022_4">Visual Studio 2022, 17.4</string>
 
       <!-- Convey a particular version and higher. -->
-      <string id="VisualStudio2017">Visual Studio 2017 and higher.</string>
-      <string id="VisualStudio2019">Visual Studio 2019 and higher.</string>
-      <string id="VisualStudio2022">Visual Studio 2022 and higher.</string>
+      <string id="VisualStudio2017AndHigher">Visual Studio 2017 and higher.</string>
+      <string id="VisualStudio2019AndHigher">Visual Studio 2019 and higher.</string>
+      <string id="VisualStudio2022AndHigher">Visual Studio 2022 and higher.</string>
       <string id="VisualStudio2022_1">Visual Studio 2022, 17.1 and higher.</string>
       <string id="VisualStudio2022_4">Visual Studio 2022, 17.4 and higher.</string>
 


### PR DESCRIPTION
## What
Update the displayName string in the adml file to support "SupportedOn" tag in Windows Intune.

## Why
When Windows tries to populate the SupportedOn button in Intune from our admx files, they currently cannot find the text associated to the definition.  This is because they look for a string in the adml file that matches the definition name.

## How
This PR changes the names of the strings referenced by the displayName in the admx to match the definition name per Windows.