### PR TITLE
Update AllowStandardUserControl policy to use 0 as disabled

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -295,13 +295,27 @@
             valueName="AllowStandardUserControl">
             <parentCategory ref="InstallandUpdateSettings"/>
             <supportedOn ref="VisualStudio2017AndHigher"/>
+            <enabledList>
+                <item key="Software\Policies\Microsoft\VisualStudio\Setup" valueName="AllowStandardUserControl">
+                  <value>
+                    <decimal value="1" />
+                  </value>
+                </item>
+                <item key="Software\Policies\Microsoft\VisualStudio\Setup" valueName="AllowStandardUserControl">
+                    <value>
+                      <decimal value="2" />
+                    </value>
+                  </item>
+              </enabledList>
+            <disabledList>
+                <item key="Software\Policies\Microsoft\VisualStudio\Setup" valueName="AllowStandardUserControl">
+                    <value>
+                      <decimal value="0" />
+                    </value>
+                  </item>
+            </disabledList>
             <elements>
                 <enum id="AllowStandardUserControlDropID" valueName="AllowStandardUserControl">
-                    <item displayName="$(string.AllowStandardUserControl_Blocked)">
-                        <value>
-                            <decimal value="0" />
-                        </value>
-                    </item>
                     <item displayName="$(string.AllowStandardUserControl_EnabledForUpdateAndRollback)">
                         <value>
                             <decimal value="1" />

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -124,7 +124,7 @@ For more information, see https://aka.ms/vs/setup/policies.</string>
       <string id="AllowStandardUserControl_DisplayName">Allow standard users to execute installer operations</string>
       <string id="AllowStandardUserControl_Explain">Allows users without administrator permissions to manage their Visual Studio installations. 
         
-If set to 0 (blocked) or missing entirely, the installer will prompt for administrator permissions using UAC.        
+If set to 0 (disabled) or missing entirely, the installer will prompt for administrator permissions using UAC.        
 
 If set to 1 (enabled for Update and Rollback), users without administrator permissions can update or rollback without UAC. All other operations will ask for administrator permissions through UAC.  
         
@@ -132,7 +132,6 @@ If set to 2 (enabled for all installer operations), users without administrator 
         
 For more information, see http://aka.ms/vs/setup/policies.</string>
 
-      <string id="AllowStandardUserControl_Blocked">Blocked</string>
       <string id="AllowStandardUserControl_EnabledForUpdateAndRollback">Enabled for Update and Rollback</string>
       <string id="AllowStandardUserControl_EnabledForAll">Enabled for all installer operations</string>
       


### PR DESCRIPTION
## What
Update the AllowStandardUserControl to use the `Disabled` option to turn off the feature instead of an enabled dropdown option

## Why
To disable a policy, ADMX supports a `Disabled` option. The common pattern is to use that option to disable rather than adding a dropdown option for the enabled setting.

## How
- Add an enabled list for the policy for the enabled options
- Add a disabled list for the policy fo the disabled option
- Update the ADML to account for the changes
- Remove the Blocked option from the dropdown

## Validation
- Verified enabling with `Update and Rollback` sets `HKLM\Software\Policies\Microsoft\VisualStudio\Setup\AllowStandardUserControl` to `1`
- - Verified enabling with `All` sets `HKLM\Software\Policies\Microsoft\VisualStudio\Setup\AllowStandardUserControl` to `2`
- Verified disabling deletes `HKLM\Software\Policies\Microsoft\VisualStudio\Setup\AllowStandardUserControl`

## Screenshots
![image](https://github.com/microsoft/Visual-Studio-Administrative-Templates/assets/40210514/40dd0c45-6bb8-461b-8052-9798bc938b19)
![image](https://github.com/microsoft/Visual-Studio-Administrative-Templates/assets/40210514/a284205f-fe1f-4ffc-8eef-68599dbc88d0)
