### PR TITLE
Enable TSA bug logging for CodeQL

### DIFF
--- a/.config/CodeQL/tsaoptions.json
+++ b/.config/CodeQL/tsaoptions.json
@@ -1,0 +1,8 @@
+{
+    "codebaseName": "VisualStudioAdministratorTemplates",
+    "instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
+    "projectName": "DevDiv",
+    "areaPath": "DevDiv\\VS Setup",
+    "iterationPath": "DevDiv"
+  }
+  

--- a/build/build.yml
+++ b/build/build.yml
@@ -43,6 +43,8 @@ variables:
   finalDrop: $(Build.StagingDirectory)\finalDrop
   outputNameWithExtension: VisualStudioAdminTemplates.exe
   CodeQL.Enabled: true
+  CodeQL.TSAEnabled: true
+  CodeQL.TSAOptionsPath: $(Build.SourcesDirectory)\.config\CodeQL\tsaoptions.json
 
 steps:
 - checkout: self


### PR DESCRIPTION
Enable TSA bug logging for CodeQL. This should allow us to get internal bugs whenever there is a CodeQL issue.