### PR TITLE
Update compliance build to run all required tools

### DIFF
--- a/.config/apiscan/surrogates/apiscan-surrogate.xml
+++ b/.config/apiscan/surrogates/apiscan-surrogate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<APIScanSurrogates>
+  <Mappings>
+    <!-- Map boxstub and updatedriver as surrogates for the packaged admin update. -->
+    <!-- This is necessary since we package updatedriver inside boxstub which breaks API scan tooling. -->
+    <!-- The owning team directed us to use a surrogate as well for the two packaged executables. -->
+    <Mapping>
+      <SurrogateSet>
+        <BinarySet>
+          <SymbolLocations>
+            <SymbolLocation>SRV*https://symweb</SymbolLocation>
+          </SymbolLocations>
+          <Binary path="boxstub.exe" />
+          <Binary path="ADMXExtractor.exe" />
+        </BinarySet>
+      </SurrogateSet>
+      <Targets>
+        <Binary path="VisualStudioAdminTemplates\.exe" pathType="Regex" />
+      </Targets>
+    </Mapping>
+  </Mappings>
+</APIScanSurrogates>

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -3,6 +3,7 @@
     "instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
     "projectName": "DevDiv",
     "areaPath": "DevDiv\\VS Setup",
-    "iterationPath": "DevDiv"
+    "iterationPath": "DevDiv",
+    "allTools": true
   }
   

--- a/build/build.yml
+++ b/build/build.yml
@@ -24,22 +24,13 @@ schedules:
 parameters:
 - name: signType
   type: string
+  values:
+    - real
+    - test
   default: real
 
 variables:
   TeamName: VSSetup
-  buildPlatform: 'Any CPU'
-  buildConfiguration: 'Release'
-  projectName: ADMXExtractor
-  projectDirectory: $(Build.SourcesDirectory)\src\ADMXExtractor
-  projectFullPath: $(Build.SourcesDirectory)\src\ADMXExtractor\ADMXExtractor.sln
-  publishDir: Release\net472\x86\publish\
-  logFileName: MyWpfAppSigningLog.txt
-  finalDrop: $(Build.StagingDirectory)\finalDrop
-  outputNameWithExtension: VisualStudioAdminTemplates.exe
-  CodeQL.Enabled: true
-  CodeQL.TSAEnabled: true
-  CodeQL.TSAOptionsPath: $(Build.SourcesDirectory)\.config\CodeQL\tsaoptions.json
 
 resources:
   repositories:
@@ -56,115 +47,35 @@ extends:
     sdl:
       sourceAnalysisPool:
         name: AzurePipelines-EO
-        image: AzurePipelinesWindows2022compliantGPT
+        image: 1ESPT-Windows2022
       policheck:
         enabled: true
       binskim:
         enabled: true
         scanOutputDirectoryOnly: true # BinSkim scans whole source tree but we only need to scan the output dir.
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        onboard: false # We already onboarded
 
     stages:
       - stage: Build
+        templateContext:
+          mb:
+            signing:
+              enabled: true
+              signType: ${{ parameters.SignType }}
+              feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+          
+            localization:
+              enabled: true
+              type: 'full'
+              languages: 'VS'
+              lsbuildVersion: 'V7'
+              feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+
         jobs:
           - job: Build
-            templateContext:
-              mb:
-                signing:
-                  enabled: true
-                  signType: ${{ parameters.SignType }}
-                  feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-
-                localization:
-                  enabled: true
-                  type: 'full'
-                  languages: 'VS'
-                  lsbuildVersion: 'V7'
-                  feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
-
-              outputs:
-                - output: pipelineArtifact
-                  path: '$(Build.ArtifactStagingDirectory)\ADMXExtractor' 
-                  artifactName: 'drop'
-
-                - output: pipelineArtifact
-                  displayName: Publish 'VisualStudioAdminTemplates.exe' artifact
-                  path: $(finalDrop)
-                  artifactName: exe   
-                    
             steps:
-            - checkout: self
-              submodules: true
-              persistCredentials: true
-
-            - task: NuGetToolInstaller@0
-              displayName: Install NuGet
-              inputs:
-                versionSpec: '5.8.1'
-
-            - task: NuGetAuthenticate@1
-              displayName: "NuGet Authenticate"
-              inputs:
-                nuGetServiceConnections: VSSetup-PubSuiteConnection
-
-            - task: UseDotNet@2
-              displayName: Install .NET Core SDK
-              inputs:
-                packageType: sdk
-                useGlobalJson: true
-                workingDirectory: $(Build.SourcesDirectory)
-
-            - task: NuGetCommand@2
-              displayName: NuGet restore packages.config
-              inputs:
-                restoreSolution: $(Build.SourcesDirectory)\packages.config
-                restoreDirectory: $(Build.SourcesDirectory)\packages
-                feedsToUse: config
-                nugetConfigPath: $(Build.SourcesDirectory)\nuget.config    
-
-            - task: NuGetCommand@2
-              displayName: NuGet restore ADMXExtractor.sln
-              inputs:
-                restoreSolution: $(Build.SourcesDirectory)\src\ADMXExtractor\ADMXExtractor.sln
-                restoreDirectory: $(Build.SourcesDirectory)\packages
-                feedsToUse: config
-
-            - task: PowerShell@1  
-              displayName: Install the Nerdbank Versioning tool and set the Version
-              inputs:
-                scriptType: 'inlineScript'
-                inlineScript: |
-                  dotnet tool install --tool-path . nbgv
-                  $version = .\nbgv get-version -v Version
-                  Write-Host "Setting Version to $version"
-                  Write-Host "##vso[task.setvariable variable=Version;]$version"
-
-            - task: MSBuild@1
-              displayName: Build ADMXExtractor.csproj
-              inputs:
-                solution: $(Build.SourcesDirectory)\src\ADMXExtractor\ADMXExtractor.sln
-                msbuildArguments: >
-                  /v:diag
-                  /p:OutDir=$(Build.StagingDirectory)\$(projectName)\
-                  /p:Version=$(Version)
-
-            - task: PowerShell@2
-              name: PrepareStagingDirectoryForSelfExtractor
-              displayName: Prepare the intermediate staging directory for the SelfExtractor.
-              inputs:
-                workingDirectory: $(Build.SourcesDirectory)
-                filePath: $(Build.SourcesDirectory)\build\PrepareStagingDirectoryForSelfExtractor.ps1
-                arguments:  -ArtifactsDir $(Build.StagingDirectory)\$(projectName)\ -IntermediateDropPath $(Build.StagingDirectory)\$(projectName)\Intermediate\  -Verbose
-
-            - task: PowerShell@2
-              name: GenerateSelfExtractor
-              displayName: Generate the self extracting .exe for ADMXExtractor and all admx files.
-              inputs:
-                workingDirectory: $(Build.SourcesDirectory)
-                filePath: $(Build.SourcesDirectory)\build\ADMXExtractor\GenerateSelfExtractor.ps1
-                arguments:  -RootDir $(Build.SourcesDirectory) -ArtifactsDir $(Build.StagingDirectory)\$(projectName)\Intermediate\ -ArtifactsDropTarget $(finalDrop) -OutputNameWithExtension $(outputNameWithExtension) -Verbose
-
-            - task: MSBuild@1
-              displayName: Sign packages
-              inputs:
-                solution: build\ADMXExtractor\ADMXExtractor.signproj
-                msbuildArguments: '/v:diag /t:Build /p:OutDir=$(finalDrop) /p:TargetFileToSign=$(finalDrop)\$(outputNameWithExtension)' 
+              - template: /build/templates/build-steps-template.yml@self
+              

--- a/build/templates/build-steps-template.yml
+++ b/build/templates/build-steps-template.yml
@@ -10,6 +10,7 @@ steps:
   - checkout: self
     submodules: true
     persistCredentials: true
+    fetchDepth: -1
 
   - task: NuGetToolInstaller@0
     displayName: Install NuGet

--- a/build/templates/build-steps-template.yml
+++ b/build/templates/build-steps-template.yml
@@ -59,7 +59,7 @@ steps:
       solution: $(Build.SourcesDirectory)\src\ADMXExtractor\ADMXExtractor.sln
       msbuildArguments: >
         /v:diag
-        /p:OutDir=$(Build.StagingDirectory)\${{ projectName }}\
+        /p:OutDir=$(Build.StagingDirectory)\${{ parameters.projectName }}\
         /p:Version=$(Version)
 
   - task: PowerShell@2
@@ -68,7 +68,7 @@ steps:
     inputs:
       workingDirectory: $(Build.SourcesDirectory)
       filePath: $(Build.SourcesDirectory)\build\PrepareStagingDirectoryForSelfExtractor.ps1
-      arguments:  -ArtifactsDir $(Build.StagingDirectory)\${{ projectName }}\ -IntermediateDropPath $(Build.StagingDirectory)\${{ projectName }}\Intermediate\  -Verbose
+      arguments:  -ArtifactsDir $(Build.StagingDirectory)\${{ parameters.projectName }}\ -IntermediateDropPath $(Build.StagingDirectory)\${{ parameters.projectName }}\Intermediate\  -Verbose
 
   - task: PowerShell@2
     name: GenerateSelfExtractor
@@ -76,13 +76,13 @@ steps:
     inputs:
       workingDirectory: $(Build.SourcesDirectory)
       filePath: $(Build.SourcesDirectory)\build\ADMXExtractor\GenerateSelfExtractor.ps1
-      arguments:  -RootDir $(Build.SourcesDirectory) -ArtifactsDir $(Build.StagingDirectory)\${{ projectName }}\Intermediate\ -ArtifactsDropTarget ${{ finalDrop }} -OutputNameWithExtension ${{ outputNameWithExtension }} -Verbose
+      arguments:  -RootDir $(Build.SourcesDirectory) -ArtifactsDir $(Build.StagingDirectory)\${{ parameters.projectName }}\Intermediate\ -ArtifactsDropTarget ${{ parameters.finalDrop }} -OutputNameWithExtension ${{ parameters.outputNameWithExtension }} -Verbose
 
   - task: MSBuild@1
     displayName: Sign packages
     inputs:
       solution: build\ADMXExtractor\ADMXExtractor.signproj
-      msbuildArguments: '/v:diag /t:Build /p:OutDir=${{ finalDrop }} /p:TargetFileToSign=${{ finalDrop }}\${{ outputNameWithExtension }}' 
+      msbuildArguments: '/v:diag /t:Build /p:OutDir=${{ parameters.finalDrop }} /p:TargetFileToSign=${{ parameters.finalDrop }}\${{ parameters.outputNameWithExtension }}' 
 
   - task: 1ES.PublishPipelineArtifact@1
     displayName: Publish ADMExtractor
@@ -93,5 +93,5 @@ steps:
   - task: 1ES.PublishPipelineArtifact@1
     displayName: Publish 'VisualStudioAdminTemplates.exe' artifact
     inputs:
-      targetPath: ${{ finalDrop }}
+      targetPath: ${{ parameters.finalDrop }}
       artifactName: exe   

--- a/build/templates/build-steps-template.yml
+++ b/build/templates/build-steps-template.yml
@@ -18,8 +18,6 @@ steps:
 
   - task: NuGetAuthenticate@1
     displayName: "NuGet Authenticate"
-    inputs:
-      nuGetServiceConnections: VSSetup-PubSuiteConnection
 
   - task: UseDotNet@2
     displayName: Install .NET Core SDK

--- a/build/templates/build-steps-template.yml
+++ b/build/templates/build-steps-template.yml
@@ -1,0 +1,97 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+parameters:
+  projectName: ADMXExtractor
+  finalDrop: $(Build.StagingDirectory)\finalDrop
+  outputNameWithExtension: VisualStudioAdminTemplates.exe
+          
+steps:
+  - checkout: self
+    submodules: true
+    persistCredentials: true
+
+  - task: NuGetToolInstaller@0
+    displayName: Install NuGet
+    inputs:
+      versionSpec: '5.8.1'
+
+  - task: NuGetAuthenticate@1
+    displayName: "NuGet Authenticate"
+    inputs:
+      nuGetServiceConnections: VSSetup-PubSuiteConnection
+
+  - task: UseDotNet@2
+    displayName: Install .NET Core SDK
+    inputs:
+      packageType: sdk
+      useGlobalJson: true
+      workingDirectory: $(Build.SourcesDirectory)
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore packages.config
+    inputs:
+      restoreSolution: $(Build.SourcesDirectory)\packages.config
+      restoreDirectory: $(Build.SourcesDirectory)\packages
+      feedsToUse: config
+      nugetConfigPath: $(Build.SourcesDirectory)\nuget.config    
+
+  - task: NuGetCommand@2
+    displayName: NuGet restore ADMXExtractor.sln
+    inputs:
+      restoreSolution: $(Build.SourcesDirectory)\src\ADMXExtractor\ADMXExtractor.sln
+      restoreDirectory: $(Build.SourcesDirectory)\packages
+      feedsToUse: config
+
+  - task: PowerShell@1  
+    displayName: Install the Nerdbank Versioning tool and set the Version
+    inputs:
+      scriptType: 'inlineScript'
+      inlineScript: |
+        dotnet tool install --tool-path . nbgv
+        $version = .\nbgv get-version -v Version
+        Write-Host "Setting Version to $version"
+        Write-Host "##vso[task.setvariable variable=Version;]$version"
+
+  - task: MSBuild@1
+    displayName: Build ADMXExtractor.csproj
+    inputs:
+      solution: $(Build.SourcesDirectory)\src\ADMXExtractor\ADMXExtractor.sln
+      msbuildArguments: >
+        /v:diag
+        /p:OutDir=$(Build.StagingDirectory)\${{ projectName }}\
+        /p:Version=$(Version)
+
+  - task: PowerShell@2
+    name: PrepareStagingDirectoryForSelfExtractor
+    displayName: Prepare the intermediate staging directory for the SelfExtractor.
+    inputs:
+      workingDirectory: $(Build.SourcesDirectory)
+      filePath: $(Build.SourcesDirectory)\build\PrepareStagingDirectoryForSelfExtractor.ps1
+      arguments:  -ArtifactsDir $(Build.StagingDirectory)\${{ projectName }}\ -IntermediateDropPath $(Build.StagingDirectory)\${{ projectName }}\Intermediate\  -Verbose
+
+  - task: PowerShell@2
+    name: GenerateSelfExtractor
+    displayName: Generate the self extracting .exe for ADMXExtractor and all admx files.
+    inputs:
+      workingDirectory: $(Build.SourcesDirectory)
+      filePath: $(Build.SourcesDirectory)\build\ADMXExtractor\GenerateSelfExtractor.ps1
+      arguments:  -RootDir $(Build.SourcesDirectory) -ArtifactsDir $(Build.StagingDirectory)\${{ projectName }}\Intermediate\ -ArtifactsDropTarget ${{ finalDrop }} -OutputNameWithExtension ${{ outputNameWithExtension }} -Verbose
+
+  - task: MSBuild@1
+    displayName: Sign packages
+    inputs:
+      solution: build\ADMXExtractor\ADMXExtractor.signproj
+      msbuildArguments: '/v:diag /t:Build /p:OutDir=${{ finalDrop }} /p:TargetFileToSign=${{ finalDrop }}\${{ outputNameWithExtension }}' 
+
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: Publish ADMExtractor
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)\ADMXExtractor' 
+      artifactName: 'drop'
+
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: Publish 'VisualStudioAdminTemplates.exe' artifact
+    inputs:
+      targetPath: ${{ finalDrop }}
+      artifactName: exe   

--- a/compliance.yml
+++ b/compliance.yml
@@ -86,6 +86,15 @@ extends:
       - stage: Build
         jobs:
           - job: Build
+            templateContext:
+              mb:
+                localization:
+                  enabled: true
+                  type: 'full'
+                  languages: 'VS'
+                  lsbuildVersion: 'V7'
+                  feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+
             steps:
               - template: /build/templates/build-steps-template.yml@self
                 parameters:
@@ -98,7 +107,6 @@ extends:
                 inputs:
                   SourceFolder: $(Build.ArtifactStagingDirectory)
                   Contents: |
-                    **\$(OutputName).?(exe|pdb|dll|xml)
                     **\$(ProjectName)\*.?(exe|pdb|dll|xml)
                     !**\*.Test.*
                   TargetFolder: $(Build.StagingDirectory)\apiscan-inputs

--- a/compliance.yml
+++ b/compliance.yml
@@ -5,6 +5,12 @@ schedules:
     include: 
     - main
 
+parameters:
+  - name: LogBugs
+    displayName: Log bugs?
+    type: boolean
+    default: true
+
 variables:
   - group: vssetup-apiscan
   - group: vssetup-apiscan-secrets
@@ -42,7 +48,7 @@ extends:
       prefast:
         enabled: true
       tsa:
-        enabled: true
+        enabled: ${{ parameters.LogBugs }}
         configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
         onboard: false # We already onboarded
 
@@ -126,5 +132,5 @@ extends:
                   GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
                   GdnPublishTsaExportedResultsPublishable: true
                 continueOnError: true
-                condition: succeededOrFailed()
+                condition: and(succeededOrFailed(), eq(${{ parameters.LogBugs }}, 'true'))
                 enabled: true

--- a/compliance.yml
+++ b/compliance.yml
@@ -30,25 +30,15 @@ extends:
     pool:
       name: VSEngSS-MicroBuild2022-1ES
     sdl:
+      enableAllTools: true
       sourceAnalysisPool:
         name: AzurePipelines-EO
         image: 1ESPT-Windows2022
-      antimalwareScan:
-        enabled: true
-      armory:
-        enabled: true
       binskim:
-        enabled: true
         scanOutputDirectoryOnly: true
       codeql:
         compiled:
           enabled: true
-      credscan:
-        enabled: true
-      policheck:
-        enabled: true
-      psscriptanalyzer:
-        enabled: true
       prefast:
         enabled: true
       tsa:
@@ -88,19 +78,21 @@ extends:
                   flattenFolders: true
 
               - task: CopyFiles@2
-                displayName: Copy BoxStub PDB for API scan
+                displayName: Copy BoxStub for API scan
                 inputs:
                   SourceFolder: $(Build.SourcesDirectory)
                   Contents: |
-                    packages\VS.Setup.BootstrapperExternals*\**\boxstub.pdb
+                    packages\VS.Setup.BootstrapperExternals*\**\boxstub.?(exe|pdb)
                   TargetFolder: $(Build.StagingDirectory)\apiscan-inputs
                   flattenFolders: true
 
-              # - task: PowerShell@2
-              #   displayName: Rename BoxStub PDB for API scan
-              #   inputs:
-              #     targetType: inline
-              #     script: Rename-Item -Path "$(Build.StagingDirectory)\apiscan-inputs\boxstub.pdb" -NewName "$(OutputName).pdb"
+              - task: CopyFiles@2
+                displayName: Copy surrogate file for API scan
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)\.config\apiscan\surrogates
+                  Contents: |
+                    apiscan-surrogate.xml
+                  TargetFolder: $(System.ArtifactsDirectory)\apiscan-inputs
 
               - task: APIScan@2
                 displayName: Run APIScan
@@ -109,6 +101,7 @@ extends:
                   softwareName: 'Microsoft.VisualStudioAdministrativeTemplates'
                   softwareVersionNum: '1'
                   toolVersion: Latest
+                  surrogateConfigurationFolder: $(System.ArtifactsDirectory)\apiscan-inputs
                 env:
                   AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(SetupAppApiScanSecret)
 

--- a/compliance.yml
+++ b/compliance.yml
@@ -1,29 +1,3 @@
-parameters:
-  - name: BuildPlatform
-    displayName: Build platform
-    type: string
-    default: 'Any CPU'
-    values:
-      - 'Any CPU'
-      - 'x86'
-      - 'x64'
-
-  - name: BuildConfiguration
-    displayName: Build configuration
-    type: string
-    default: Release
-    values:
-      - Release
-    
-  - name: BinSkimSeverity
-    displayName: BinSkim severity
-    type: string
-    default: Error
-    values:
-      - Error
-      - Note
-      - Warning
-
 schedules:
 - cron: '0 0 */21 * *'
   displayName: 'Run every 21 days at 12:00 a.m.'
@@ -107,6 +81,7 @@ extends:
                 inputs:
                   SourceFolder: $(Build.ArtifactStagingDirectory)
                   Contents: |
+                    **\$(OutputName).?(exe|pdb|dll|xml)
                     **\$(ProjectName)\*.?(exe|pdb|dll|xml)
                     !**\*.Test.*
                   TargetFolder: $(Build.StagingDirectory)\apiscan-inputs

--- a/compliance.yml
+++ b/compliance.yml
@@ -85,6 +85,22 @@ extends:
                     **\$(ProjectName)\*.?(exe|pdb|dll|xml)
                     !**\*.Test.*
                   TargetFolder: $(Build.StagingDirectory)\apiscan-inputs
+                  flattenFolders: true
+
+              - task: CopyFiles@2
+                displayName: Copy BoxStub PDB for API scan
+                inputs:
+                  SourceFolder: $(Build.SourcesDirectory)
+                  Contents: |
+                    packages\VS.Setup.BootstrapperExternals*\**\boxstub.pdb
+                  TargetFolder: $(Build.StagingDirectory)\apiscan-inputs
+                  flattenFolders: true
+
+              # - task: PowerShell@2
+              #   displayName: Rename BoxStub PDB for API scan
+              #   inputs:
+              #     targetType: inline
+              #     script: Rename-Item -Path "$(Build.StagingDirectory)\apiscan-inputs\boxstub.pdb" -NewName "$(OutputName).pdb"
 
               - task: APIScan@2
                 displayName: Run APIScan

--- a/compliance.yml
+++ b/compliance.yml
@@ -47,6 +47,8 @@ extends:
           enabled: true
       prefast:
         enabled: true
+      roslyn:
+        break: false
       tsa:
         enabled: ${{ parameters.LogBugs }}
         configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json

--- a/compliance.yml
+++ b/compliance.yml
@@ -1,31 +1,28 @@
-pool: VSEngSS-MicroBuild2022-1ES
-
 parameters:
-- name: BuildPlatform
-  displayName: Build platform
-  type: string
-  default: 'Any CPU'
-  values:
-  - 'Any CPU'
-  - 'x86'
-  - 'x64'
-- name: BuildConfiguration
-  displayName: Build configuration
-  type: string
-  default: Release
-  values:
-  - Release
-- name: BinSkimSeverity
-  displayName: BinSkim severity
-  type: string
-  default: Error
-  values:
-  - Error
-  - Note
-  - Warning
+  - name: BuildPlatform
+    displayName: Build platform
+    type: string
+    default: 'Any CPU'
+    values:
+      - 'Any CPU'
+      - 'x86'
+      - 'x64'
 
-variables:
-  CodeQL.Enabled: true
+  - name: BuildConfiguration
+    displayName: Build configuration
+    type: string
+    default: Release
+    values:
+      - Release
+    
+  - name: BinSkimSeverity
+    displayName: BinSkim severity
+    type: string
+    default: Error
+    values:
+      - Error
+      - Note
+      - Warning
 
 schedules:
 - cron: '0 0 */21 * *'
@@ -34,69 +31,108 @@ schedules:
     include: 
     - main
 
-steps:
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk matching global.json'
-  inputs:
-    packageType: sdk
-    useGlobalJson: true
-    workingDirectory: $(Build.SourcesDirectory)
-    performMultiLevelLookup: true
+variables:
+  - group: vssetup-apiscan
+  - group: vssetup-apiscan-secrets
+  - name: TeamName
+    value: VSSetup
+  - name: OutputName
+    value: VisualStudioAdminTemplates
+  - name: FinalDropPath
+    value: $(Build.StagingDirectory)\finalDrop
+  - name: ProjectName
+    value: ADMXExtractor
 
-- task: CodeQL3000Init@0
+resources:
+  repositories:
+    - repository: MicroBuildTemplate
+      type: git
+      name: 1ESPipelineTemplates/MicroBuildTemplate
+      ref: refs/tags/release
 
-- task: NuGetToolInstaller@1
-  displayName: Install NuGet
-  inputs:
-    versionSpec: '6.x'
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-MicroBuild2022-1ES
+    sdl:
+      sourceAnalysisPool:
+        name: AzurePipelines-EO
+        image: 1ESPT-Windows2022
+      antimalwareScan:
+        enabled: true
+      armory:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true
+      codeql:
+        compiled:
+          enabled: true
+      credscan:
+        enabled: true
+      policheck:
+        enabled: true
+      psscriptanalyzer:
+        enabled: true
+      prefast:
+        enabled: true
+      tsa:
+        enabled: true
+        configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
+        onboard: false # We already onboarded
 
-- task: NuGetCommand@2
-  inputs:
-    command: 'restore'
+    stages:
+      - stage: Build
+        jobs:
+          - job: Build
+            steps:
+              - template: /build/templates/build-steps-template.yml@self
+                parameters:
+                  outputNameWithExtension: $(OutputName).exe
+                  finalDrop: $(FinalDropPath)
+                  projectName: $(ProjectName)
 
-- task: VSBuild@1
-  inputs:
-    solution: '**/*.sln'
-    maximumCpuCount: true
-    platform: '${{ parameters.BuildPlatform }}'
-    configuration: '${{ parameters.BuildConfiguration }}'
+              - task: CopyFiles@2
+                displayName: Copy files for API scan
+                inputs:
+                  SourceFolder: $(Build.ArtifactStagingDirectory)
+                  Contents: |
+                    **\$(OutputName).?(exe|pdb|dll|xml)
+                    **\$(ProjectName)\*.?(exe|pdb|dll|xml)
+                    !**\*.Test.*
+                  TargetFolder: $(Build.StagingDirectory)\apiscan-inputs
 
-- task: CodeQL3000Finalize@0
+              - task: APIScan@2
+                displayName: Run APIScan
+                inputs:
+                  softwareFolder: $(Build.StagingDirectory)\apiscan-inputs
+                  softwareName: 'Microsoft.VisualStudioAdministrativeTemplates'
+                  softwareVersionNum: '1'
+                  toolVersion: Latest
+                env:
+                  AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId);TenantId=$(ApiScanTenant);AppKey=$(SetupAppApiScanSecret)
 
-- task: PoliCheck@2
-  displayName: 'Run PoliCheck'
-  inputs:
-    targetType: F
-    targetArgument: '$(Build.SourcesDirectory)'
-    optionsFC: 0
-    optionsXS: 1
-    optionsHMENABLE: 0
-  continueOnError: true
+              - task: PublishSecurityAnalysisLogs@3
+                displayName: Publish 'SDLAnalysis-APIScan' artifact
+                condition: succeededOrFailed()
+                inputs:
+                  ArtifactName: SDLAnalysis-APIScan
+                  AllTools: false
+                  APIScan: true
 
-- task: CredScan@3
-  displayName: 'Run CredScan'
-  inputs:
-    debugMode: false
-    toolMajorVersion: V2
-
-- task: BinSkim@4
-  displayName: 'Run BinSkim'
-  inputs:
-    InputType: Basic
-    Function: analyze
-    TargetPattern: guardianGlob
-    AnalyzeTargetGlob: $(Build.SourcesDirectory)/**.dll;$(Build.SourcesDirectory)/**.exe;
-    AnalyzeSymPath: 'Srv*http://msdl.microsoft.com/download/symbols'
-    AnalyzeLocalSymbolDirectories: $(Build.SourcesDirectory)
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-  continueOnError: true
-
-- task: PublishSecurityAnalysisLogs@3
-  displayName: 'Publish Security Analysis Logs'
-
-- task: PostAnalysis@2
-  displayName: 'Check SDL results'
-  inputs:
-    AllTools: true
-    GdnBreakGdnToolBinSkimSeverity: '${{ parameters.BinSkimSeverity }}'
+              - task: PostAnalysis@2
+                displayName: Post Analysis
+                inputs:
+                  GdnBreakAllTools: false
+                  GdnBreakGdnToolApiScan: true
+                
+              - task: TSAUpload@2
+                displayName: Upload APIScan results to TSA
+                inputs:
+                  GdnPublishTsaOnboard: false
+                  GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\.config\tsaoptions.json'
+                  GdnPublishTsaExportedResultsPublishable: true
+                continueOnError: true
+                condition: succeededOrFailed()
+                enabled: true

--- a/compliance.yml
+++ b/compliance.yml
@@ -5,6 +5,8 @@ schedules:
     include: 
     - main
 
+trigger: none
+
 parameters:
   - name: LogBugs
     displayName: Log bugs?

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" developmentDependency="true" />
-  <package id="VS.Setup.BootstrapperExternals" version="3.4.7-g3d49b5b8" developmentDependency="true" />
+  <package id="VS.Setup.BootstrapperExternals" version="3.10.1108" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Update compliance build to run all required tools. Wires in API scan which is required for all shipping code, and ensures we log bugs for any issues.