### PR TITLE
Add 'in Visual Studio' suffix to Copilot settings

### DIFF
--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -182,9 +182,9 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <string id="VSDevTunnelsDisable__Explain">This policy disables dev tunnels in Visual Studio. For more information, see: https://aka.ms/devtunnels/vs/admx</string>
 
       <!-- GitHub Copilot -->
-      <string id="DisableCopilot_DisplayName">Disable Copilot</string>
+      <string id="DisableCopilot_DisplayName">Disable Copilot in Visual Studio</string>
       <string id="DisableCopilot_Explain">If this setting is enabled, it will prevent your users from using any GitHub Copilot license (GitHub Copilot for Business, GitHub Copilot for Enterprise, and Copilot for Individual). For more information, see: https://aka.ms/CopilotGroupPolicy</string>
-      <string id="DisableCopilotForIndividuals_DisplayName">Disable Copilot for Individual</string>
+      <string id="DisableCopilotForIndividuals_DisplayName">Disable Copilot for Individual in Visual Studio</string>
       <string id="DisableCopilotForIndividuals_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot for Individual. GitHub Copilot for Business and GitHub Copilot for Enterprise will still be enabled. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
 
     </stringTable>


### PR DESCRIPTION
Since there are many new Copilot integrations the current display names can be confusing.