### PR TITLE
Turn off codesign validation for compliance builds

### DIFF
--- a/compliance.yml
+++ b/compliance.yml
@@ -51,6 +51,8 @@ extends:
         enabled: true
       roslyn:
         break: false
+      codeSignValidation:
+        enabled: false # We don't sign our compliance builds
       tsa:
         enabled: ${{ parameters.LogBugs }}
         configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json


### PR DESCRIPTION
Turns off codesign validation for compliance builds. We don't sign these builds, so there is no reason to validate signatures. Verified that a compliance build from this branch does not enable codesign validation.