### PR TITLE
Fixup various analyzer warnings

### DIFF
--- a/src/ADMXExtractor/AssemblyInfo.cs
+++ b/src/ADMXExtractor/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Windows;
 
+[assembly: NeutralResourcesLanguage("en")]
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
                                      //(used if a resource is not found in the page,

--- a/src/ADMXExtractor/View/MainWindow.xaml.cs
+++ b/src/ADMXExtractor/View/MainWindow.xaml.cs
@@ -56,7 +56,7 @@ namespace ADMXExtractor
         {
             Hide();
 
-            var browseForFolder = new FolderBrowserDialog();
+            using var browseForFolder = new FolderBrowserDialog();
             browseForFolder.RootFolder = Environment.SpecialFolder.MyComputer;
 
             var winDirPath = Environment.GetFolderPath(Environment.SpecialFolder.Windows);

--- a/src/ADMXExtractor/View/MainWindow.xaml.cs
+++ b/src/ADMXExtractor/View/MainWindow.xaml.cs
@@ -73,7 +73,7 @@ namespace ADMXExtractor
             {
                 // If the user closes or aborts the FolderBrowserDialog by clicking "Cancel" or by clicking the "X" in the upper right corner,
                 // exit the application.
-                messageBoxText = string.Format(Strings.FileExtractionCancel);
+                messageBoxText = Strings.FileExtractionCancel;
                 messageBoxImage = (MessageBoxImage)MessageBoxIcon.Information;
             }
             else


### PR DESCRIPTION
We have 2 analyzer warnings:
- Missing `NeutralResourcesLanguageAttribute` on the assembly
- Not disposing of the `FolderBrowserDialog`

This PR fixes both of these, adding `en` as the neutral language and a `using` to dispose of the `FolderBrowserDialog`. It also removes an extraneous `string.Format` that is not needed.

The `NeutralResourcesLanguageAttribute` is used by .NET to identify which language is stored in the assembly and doesn't have a satellite assembly.