### PR TITLE
Update admx with reference refs for VS 2022.10 and 2022.12 and higher.

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -40,12 +40,12 @@
                     <reference ref="VisualStudio2022"/>
                 </and>
             </definition>
-            <definition name="VisualStudio2022_10AndHigher" displayName="$(string.VisualStudio2022_10)">
+            <definition name="VisualStudio2022_10AndHigher" displayName="$(string.VisualStudio2022_10AndHigher)">
                 <and>
                     <reference ref="VisualStudio2022_10"/>
                 </and>
             </definition>
-	        <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12)">
+	        <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12AndHigher)">
                 <and>
                     <reference ref="VisualStudio2022_12"/>
                 </and>

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -41,9 +41,15 @@
                 </and>
             </definition>
             <definition name="VisualStudio2022_10AndHigher" displayName="$(string.VisualStudio2022_10)">
+                <and>
+                    <reference ref="VisualStudio2022_10"/>
+                </and>
             </definition>
-	    <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12)">
-	    </definition>
+	        <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12)">
+                <and>
+                    <reference ref="VisualStudio2022_12"/>
+                </and>
+	        </definition>
         </definitions>
     </supportedOn>
     <categories>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -35,7 +35,7 @@
       <string id="VisualStudio2022AndHigher">Visual Studio 2022 and higher.</string>
       <string id="VisualStudio2022_1">Visual Studio 2022, 17.1 and higher.</string>
       <string id="VisualStudio2022_4">Visual Studio 2022, 17.4 and higher.</string>
-      <string id="VisualStudio2022_10">Visual Studio 2022, 17.10 and higher.</string>
+      <string id="VisualStudio2022_10AndHigher">Visual Studio 2022, 17.10 and higher.</string>
       <string id="VisualStudio2022_12">Visual Studio 2022, 17.12 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->


### PR DESCRIPTION
Update the admx file to properly reference specific version of VS, fixing an issue where the "Supported On" UX in Intune was not displaying properly.

The root of this problem is that Intune uses the "definition name" to find the string to display in the ADML.  

This seems like a bug on Intune.  They should be pulling from the displayName.

In any case, fixing now.

![error](https://github.com/user-attachments/assets/e63e951f-949b-4977-a963-d7b0719c16f2)

