### PR TITLE
Fix Code Sign Validation warnings

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -57,6 +57,10 @@ extends:
         enabled: true
         configFile: $(Build.SourcesDirectory)\.config\tsaoptions.json
         onboard: false # We already onboarded
+      codeSignValidation:
+        enabled: true
+        excludePassesFromLog: true # A *lot* of things pass CSV. Setting this to true avoids the logs ballooning to an outrageous size.
+        additionalTargetsGlobPattern: -|tests\**;-:f|**\boxstub.exe # Tests aren't signed. Boxstub.exe is signed as part of bootstrapper generation.
 
     stages:
       - stage: Build

--- a/build/templates/build-steps-template.yml
+++ b/build/templates/build-steps-template.yml
@@ -67,7 +67,7 @@ steps:
     inputs:
       workingDirectory: $(Build.SourcesDirectory)
       filePath: $(Build.SourcesDirectory)\build\PrepareStagingDirectoryForSelfExtractor.ps1
-      arguments:  -ArtifactsDir $(Build.StagingDirectory)\${{ parameters.projectName }}\ -IntermediateDropPath $(Build.StagingDirectory)\${{ parameters.projectName }}\Intermediate\  -Verbose
+      arguments:  -ArtifactsDir $(Build.StagingDirectory)\${{ parameters.projectName }}\ -IntermediateDropPath $(Pipeline.Workspace)\${{ parameters.projectName }}\Intermediate\  -Verbose
 
   - task: PowerShell@2
     name: GenerateSelfExtractor
@@ -75,7 +75,7 @@ steps:
     inputs:
       workingDirectory: $(Build.SourcesDirectory)
       filePath: $(Build.SourcesDirectory)\build\ADMXExtractor\GenerateSelfExtractor.ps1
-      arguments:  -RootDir $(Build.SourcesDirectory) -ArtifactsDir $(Build.StagingDirectory)\${{ parameters.projectName }}\Intermediate\ -ArtifactsDropTarget ${{ parameters.finalDrop }} -OutputNameWithExtension ${{ parameters.outputNameWithExtension }} -Verbose
+      arguments:  -RootDir $(Build.SourcesDirectory) -ArtifactsDir $(Pipeline.Workspace)\${{ parameters.projectName }}\Intermediate\ -ArtifactsDropTarget ${{ parameters.finalDrop }} -OutputNameWithExtension ${{ parameters.outputNameWithExtension }} -Verbose
 
   - task: MSBuild@1
     displayName: Sign packages

--- a/src/ADMXExtractor/ADMXExtractor.csproj
+++ b/src/ADMXExtractor/ADMXExtractor.csproj
@@ -33,6 +33,14 @@
     </FilesToSign>
   </ItemGroup>
 
+  <Target Name="SignLocalizedFiles" AfterTargets="Localize" BeforeTargets="SignFiles">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)\localize\**\*.resources.dll">
+        <Authenticode>MicrosoftSha2</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## What?
Fix Code Sign Validation warnings

## Why?
We are getting some CSV warnings which will soon turn into errors.

## How?
I did three things in this PR:
1) Exclude `boxtub.exe` from being scanned, as it will be signed during the bootstrapper generation stage
2) Change the intermediate folder to using `Pipeline.Worskpace` as we are supposed to. We are not supposed to use the staging directory as our workplace.
3) Sign locale files (`resources.dll`) with `MicrosoftSha2`. We should sign everything we ship.

## Validation
Verified that the pipeline passes code sign validation.