### PR TITLE
Adding AvailableTabProducts policy

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -386,7 +386,7 @@
           key="SOFTWARE\Policies\Microsoft\VisualStudio\Setup"
           valueName="AvailableTabProducts">
         <parentCategory ref="InstallandUpdateSettings" />
-        <supportedOn ref="VisualStudio2022_12AndHigher" />
+        <supportedOn ref="VisualStudio2022_13AndHigher" />
         <elements>
           <!--Text is limited to 1023 chars by admx -->
           <text id="AvailableTabProducts_TextBox" valueName="AvailableTabProducts" expandable="true"/>

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -377,6 +377,22 @@
 	    </disabledValue>
 	</policy>
 
+      <policy
+          name="AvailableTabProducts"
+          class="Machine"
+          displayName="$(string.AvailableTabProducts_DisplayName)"
+          explainText="$(string.AvailableTabProducts_Explain)"
+          presentation="$(presentation.AvailableTabProducts_PresentationId)"
+          key="SOFTWARE\Policies\Microsoft\VisualStudio\Setup"
+          valueName="AvailableTabProducts">
+        <parentCategory ref="InstallandUpdateSettings" />
+        <supportedOn ref="VisualStudio2022_12AndHigher" />
+        <elements>
+          <!--Text is limited to 1023 chars by admx -->
+          <text id="AvailableTabProducts_TextBox" valueName="AvailableTabProducts" expandable="true"/>
+        </elements>
+      </policy>
+
         <!-- LiveShare Settings -->
         <policy 
             name="LiveShareDomainName" 

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -18,6 +18,7 @@
                     <minorVersion name="VisualStudio2022_4" displayName="$(string.VisualStudioProductName2022_4)" versionIndex="4"/>
                     <minorVersion name="VisualStudio2022_10" displayName="$(string.VisualStudioProductName2022_10)" versionIndex="10"/>
                     <minorVersion name="VisualStudio2022_12" displayName="$(string.VisualStudioProductName2022_12)" versionIndex="12"/>
+                    <minorVersion name="VisualStudio2022_13" displayName="$(string.VisualStudioProductName2022_13)" versionIndex="13"/>
                 </majorVersion>
             </product>
         </products>
@@ -50,6 +51,11 @@
                     <reference ref="VisualStudio2022_12"/>
                 </and>
 	        </definition>
+          <definition name="VisualStudio2022_13AndHigher" displayName="$(string.VisualStudio2022_13AndHigher)">
+                <and>
+                  <reference ref="VisualStudio2022_13"/>
+                </and>
+          </definition>
         </definitions>
     </supportedOn>
     <categories>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -160,7 +160,7 @@ If set to a 1, the update notification in the Visual Studio IDE will be suppress
 For more information, see https://aka.ms/vs/setup/policies.</string>
 
       <string id="AvailableTabProducts_DisplayName">Control what products are available to install on the Visual Studio Installer's Available tab.</string>
-      <string id="AvailableTabProducts_Explain">This policy can be used to restrict which Visual Studio product shows up on the Installer's Available Tab. For example, including Microsoft.VisualStudio.Product.Professional in the list will cause the Visual Studio Professional edition to be the only available option to install. This policy is only applies to client machines that have just the Visual Studio Installer installed. For more information, see  https://aka.ms/vs/setup/policies.</string>
+      <string id="AvailableTabProducts_Explain">This policy can be used to restrict which Visual Studio product shows up on the Installer's Available Tab. For example, including Microsoft.VisualStudio.Product.Professional in the list will cause the Visual Studio Professional edition to be the only available option to install. This policy is only applied to client machines that have just the Visual Studio Installer installed. For more information, see  https://aka.ms/vs/setup/policies.</string>
 
 
       <!-- LiveShare -->

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -160,7 +160,7 @@ If set to a 1, the update notification in the Visual Studio IDE will be suppress
 For more information, see https://aka.ms/vs/setup/policies.</string>
 
       <string id="AvailableTabProducts_DisplayName">Control what products are available to install on the Visual Studio Installer's Available tab.</string>
-      <string id="AvailableTabProducts_Explain">Add product ids to restrict list shown in Available Tab of Visual Studio Installer. e.g. Microsoft.VisualStudio.Product.Professional. For more information, see  https://aka.ms/vs/setup/policies.</string>
+      <string id="AvailableTabProducts_Explain">This policy can be used to restrict which Visual Studio product shows up on the Installer's Available Tab. For example, including Microsoft.VisualStudio.Product.Professional in the list will cause the Visual Studio Professional edition to be the only available option to install. This policy is only applies to client machines that have just the Visual Studio Installer installed. For more information, see  https://aka.ms/vs/setup/policies.</string>
 
 
       <!-- LiveShare -->

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -159,7 +159,7 @@ If set to a 1, the update notification in the Visual Studio IDE will be suppress
 
 For more information, see https://aka.ms/vs/setup/policies.</string>
 
-      <string id="AvailableTabProducts_DisplayName">Filter and restict Available tab products in Visual Studio Installer</string>
+      <string id="AvailableTabProducts_DisplayName">Filter and restrict Available tab products in Visual Studio Installer</string>
       <string id="AvailableTabProducts_Explain">Add product ids to restrict list shown in Available Tab of Visual Studio Installer. e.g. Microsoft.VisualStudio.Product.Professional. For more information, see  https://aka.ms/vs/setup/policies.</string>
 
 

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -28,6 +28,7 @@
       <string id="VisualStudioProductName2022_4">Visual Studio 2022, 17.4</string>
       <string id="VisualStudioProductName2022_10">Visual Studio 2022, 17.10</string>
       <string id="VisualStudioProductName2022_12">Visual Studio 2022, 17.12</string>
+      <string id="VisualStudioProductName2022_13">Visual Studio 2022, 17.13</string>
 
       <!-- Convey a particular version and higher. -->
       <string id="VisualStudio2017AndHigher">Visual Studio 2017 and higher.</string>
@@ -37,6 +38,7 @@
       <string id="VisualStudio2022_4">Visual Studio 2022, 17.4 and higher.</string>
       <string id="VisualStudio2022_10AndHigher">Visual Studio 2022, 17.10 and higher.</string>
       <string id="VisualStudio2022_12AndHigher">Visual Studio 2022, 17.12 and higher.</string>
+      <string id="VisualStudio2022_13AndHigher">Visual Studio 2022, 17.13 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->
       <string id="VisualStudio2022_Enterprise_Professional">At least Visual Studio 2022, Enterprise and Professional only</string>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -159,7 +159,7 @@ If set to a 1, the update notification in the Visual Studio IDE will be suppress
 
 For more information, see https://aka.ms/vs/setup/policies.</string>
 
-      <string id="AvailableTabProducts_DisplayName">Filter and restrict Available tab products in Visual Studio Installer</string>
+      <string id="AvailableTabProducts_DisplayName">Control what products are available to install on the Visual Studio Installer's Available tab.</string>
       <string id="AvailableTabProducts_Explain">Add product ids to restrict list shown in Available Tab of Visual Studio Installer. e.g. Microsoft.VisualStudio.Product.Professional. For more information, see  https://aka.ms/vs/setup/policies.</string>
 
 

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -159,7 +159,11 @@ If set to a 1, the update notification in the Visual Studio IDE will be suppress
 
 For more information, see https://aka.ms/vs/setup/policies.</string>
 
-		<!-- LiveShare -->
+      <string id="AvailableTabProducts_DisplayName">Filter and restict Available tab products in Visual Studio Installer</string>
+      <string id="AvailableTabProducts_Explain">Add product ids to restrict list shown in Available Tab of Visual Studio Installer. e.g. Microsoft.VisualStudio.Product.Professional. For more information, see  https://aka.ms/vs/setup/policies.</string>
+
+
+      <!-- LiveShare -->
       <string id="LiveShare_DomainName_DisplayName">Allow only company domain accounts</string>
       <string id="LiveShare_DomainName_Explain">Prevents users from being able to share their session with any guests who are not part of their company or any other company that has been given access. Users must be logged in with their company email to access Live Share. If this policy is disabled, any user from any organization can access a shared Live Share session. Use ; to separate out multiple domains. For example, set the domain name as contoso.com or contoso.com;foo.com 
 For more information, see: https://aka.ms/vsls-policies </string>
@@ -221,7 +225,11 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <presentation id="AllowStandardUserControl_PresentationId">
          <dropdownList refId="AllowStandardUserControlDropID" noSort="true" defaultItem="0" />
       </presentation>
-
+      <presentation id="AvailableTabProducts_PresentationId">
+        <textBox refId="AvailableTabProducts_TextBox">
+          <label>Product Ids to display in Available Tab of Visual Studio Installer</label>
+        </textBox>
+      </presentation>
       <!-- LiveShare Presentations -->
       <presentation id="LiveShare_DomainName_PresentationId">
       <textBox refId="LiveShare_DomainName_TextBox">


### PR DESCRIPTION
Adding AvailableTabProducts policy which is a string field. This will contain product Ids like 'Microsoft.VisualStudio.Product.Professional"

Testing- Tested by following readme 

![image](https://github.com/user-attachments/assets/0b2bb843-5111-47b0-9143-49db89563a41)

![image](https://github.com/user-attachments/assets/ba678988-07c4-47b9-b93a-11e21a07855b)
