### PR TITLE
Add ProductFeedbackDisabled and SurveysDisabled policies for IDE 

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -18,6 +18,7 @@
                     <minorVersion name="VisualStudio2022_4" displayName="$(string.VisualStudioProductName2022_4)" versionIndex="4"/>
                     <minorVersion name="VisualStudio2022_10" displayName="$(string.VisualStudioProductName2022_10)" versionIndex="10"/>
                     <minorVersion name="VisualStudio2022_12" displayName="$(string.VisualStudioProductName2022_12)" versionIndex="12"/>
+                    <minorVersion name="VisualStudio2022_13" displayName="$(string.VisualStudioProductName2022_13)" versionIndex="13"/>
                 </majorVersion>
             </product>
         </products>
@@ -48,6 +49,11 @@
 	        <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12AndHigher)">
                 <and>
                     <reference ref="VisualStudio2022_12"/>
+                </and>
+	        </definition>
+            <definition name="VisualStudio2022_13AndHigher" displayName="$(string.VisualStudio2022_13AndHigher)">
+                <and>
+                    <reference ref="VisualStudio2022_13"/>
                 </and>
 	        </definition>
         </definitions>
@@ -107,7 +113,39 @@
                 <decimal value="0"/>
             </disabledValue>
         </policy>
-        
+        <policy 
+            name="ProductFeedbackDisabled"
+            class="Machine"
+            displayName="$(string.ProductFeedbackDisabled_DisplayName)"
+            explainText="$(string.ProductFeedbackDisabled_Explain)"
+            key="Software\Policies\Microsoft\VisualStudio\Feedback"
+            valueName="ProductFeedbackDisabled">
+            <parentCategory ref="FeedbackSettings" />
+            <supportedOn ref="VisualStudio2022_13AndHigher" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy 
+            name="SurveysDisabled"
+            class="Machine"
+            displayName="$(string.SurveysDisabled_DisplayName)"
+            explainText="$(string.SurveysDisabled_Explain)"
+            key="Software\Policies\Microsoft\VisualStudio\Feedback"
+            valueName="SurveysDisabled">
+            <parentCategory ref="FeedbackSettings" />
+            <supportedOn ref="VisualStudio2022_13AndHigher" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+
         <!-- Install and Update Settings -->
         <policy 
             name="RemoveOutOfSupport" 

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -46,16 +46,16 @@
                     <reference ref="VisualStudio2022_10"/>
                 </and>
             </definition>
-	        <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12AndHigher)">
+            <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12AndHigher)">
                 <and>
                     <reference ref="VisualStudio2022_12"/>
                 </and>
-	        </definition>
+            </definition>
             <definition name="VisualStudio2022_13AndHigher" displayName="$(string.VisualStudio2022_13AndHigher)">
                 <and>
                     <reference ref="VisualStudio2022_13"/>
                 </and>
-	        </definition>
+            </definition>
         </definitions>
     </supportedOn>
     <categories>

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -40,10 +40,16 @@
                     <reference ref="VisualStudio2022"/>
                 </and>
             </definition>
-            <definition name="VisualStudio2022_10AndHigher" displayName="$(string.VisualStudio2022_10)">
+            <definition name="VisualStudio2022_10AndHigher" displayName="$(string.VisualStudio2022_10AndHigher)">
+                <and>
+                    <reference ref="VisualStudio2022_10"/>
+                </and>
             </definition>
-	    <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12)">
-	    </definition>
+	        <definition name="VisualStudio2022_12AndHigher" displayName="$(string.VisualStudio2022_12AndHigher)">
+                <and>
+                    <reference ref="VisualStudio2022_12"/>
+                </and>
+	        </definition>
         </definitions>
     </supportedOn>
     <categories>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -49,9 +49,9 @@
       <string id="DisableFeedbackDialog_Explain">This policy disables the Visual Studio send-a-smile feature.</string>
       <string id="DisableScreenshotCapture_DisplayName">Disables send-a-smile's screenshot capability</string>
       <string id="DisableScreenshotCapture_Explain">This policy disables the screenshot capability in the send-a-smile feature.</string>
-      <string id="ProductFeedbackDisabled_DisplayName">Disables feedback mechanisms in the IDE.</string>
+      <string id="ProductFeedbackDisabled_DisplayName">Disables feedback mechanisms in the IDE</string>
       <string id="ProductFeedbackDisabled_Explain">This policy disables feedback mechanisms throughout the IDE, i.e. thumbs up or down, the feedback window pop-up, send-a-smile feature, info bars without survey links.</string>
-      <string id="SurveysDisabled_DisplayName">Disables external survey links.</string>
+      <string id="SurveysDisabled_DisplayName">Disables external survey links</string>
       <string id="SurveysDisabled_Explain">This policy disables survey links throughout the IDE, i.e. in the preview feature pane, bulletins, info bars with survey links.</string>
       
       <!-- Install and Update -->

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -28,6 +28,7 @@
       <string id="VisualStudioProductName2022_4">Visual Studio 2022, 17.4</string>
       <string id="VisualStudioProductName2022_10">Visual Studio 2022, 17.10</string>
       <string id="VisualStudioProductName2022_12">Visual Studio 2022, 17.12</string>
+      <string id="VisualStudioProductName2022_13">Visual Studio 2022, 17.13</string>
 
       <!-- Convey a particular version and higher. -->
       <string id="VisualStudio2017AndHigher">Visual Studio 2017 and higher.</string>
@@ -37,6 +38,7 @@
       <string id="VisualStudio2022_4">Visual Studio 2022, 17.4 and higher.</string>
       <string id="VisualStudio2022_10AndHigher">Visual Studio 2022, 17.10 and higher.</string>
       <string id="VisualStudio2022_12AndHigher">Visual Studio 2022, 17.12 and higher.</string>
+      <string id="VisualStudio2022_13AndHigher">Visual Studio 2022, 17.13 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->
       <string id="VisualStudio2022_Enterprise_Professional">At least Visual Studio 2022, Enterprise and Professional only</string>
@@ -47,6 +49,10 @@
       <string id="DisableFeedbackDialog_Explain">This policy disables the Visual Studio send-a-smile feature.</string>
       <string id="DisableScreenshotCapture_DisplayName">Disables send-a-smile's screenshot capability</string>
       <string id="DisableScreenshotCapture_Explain">This policy disables the screenshot capability in the send-a-smile feature.</string>
+      <string id="ProductFeedbackDisabled_DisplayName">Disables feedback mechanisms in the IDE.</string>
+      <string id="ProductFeedbackDisabled_Explain">This policy disables feedback mechanisms throughout the IDE, i.e. thumbs up or down, the feedback window pop-up, send-a-smile feature, info bars without survey links.</string>
+      <string id="SurveysDisabled_DisplayName">Disables external survey links.</string>
+      <string id="SurveysDisabled_Explain">This policy disables survey links throughout the IDE, i.e. in the preview feature pane, bulletins, info bars with survey links.</string>
       
       <!-- Install and Update -->
       <string id="RemoveOutOfSupport_DisplayName">Remove out-of-support components during updates</string>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -35,7 +35,7 @@
       <string id="VisualStudio2022AndHigher">Visual Studio 2022 and higher.</string>
       <string id="VisualStudio2022_1">Visual Studio 2022, 17.1 and higher.</string>
       <string id="VisualStudio2022_4">Visual Studio 2022, 17.4 and higher.</string>
-      <string id="VisualStudio2022_10">Visual Studio 2022, 17.10 and higher.</string>
+      <string id="VisualStudio2022_10AndHigher">Visual Studio 2022, 17.10 and higher.</string>
       <string id="VisualStudio2022_12">Visual Studio 2022, 17.12 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -36,7 +36,7 @@
       <string id="VisualStudio2022_1">Visual Studio 2022, 17.1 and higher.</string>
       <string id="VisualStudio2022_4">Visual Studio 2022, 17.4 and higher.</string>
       <string id="VisualStudio2022_10AndHigher">Visual Studio 2022, 17.10 and higher.</string>
-      <string id="VisualStudio2022_12">Visual Studio 2022, 17.12 and higher.</string>
+      <string id="VisualStudio2022_12AndHigher">Visual Studio 2022, 17.12 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->
       <string id="VisualStudio2022_Enterprise_Professional">At least Visual Studio 2022, Enterprise and Professional only</string>


### PR DESCRIPTION
Adds two new policies to support admin opt-out of feedback.
- `ProductFeedbackDisabled`
- `SurveysDisabled`

Closed https://github.com/microsoft/Visual-Studio-Administrative-Templates/pull/126 and opened this in hopes to getting compliance passing.