### PR TITLE
Bump .net core sdk version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.111",
     "rollForward": "minor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.301",
+    "version": "8.0.0",
     "rollForward": "minor"
   }
 }


### PR DESCRIPTION
## What
Bump .net core sdk version

## Why
nbgv tool isn't supported on .net core sdk 6.x.x, bumping to 8.x.x

## How
Bump the version in global.json

## Testing
Ran test pipeline and verified it succeeded