### PR TITLE
Enable PME signing and allow only real sign for the CI pipeline

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -21,16 +21,9 @@ schedules:
     include:
     - main
 
-parameters:
-- name: signType
-  type: string
-  values:
-    - real
-    - test
-  default: real
-
 variables:
   TeamName: VSSetup
+  SignType: Real
 
 resources:
   repositories:
@@ -70,8 +63,9 @@ extends:
               mb:
                 signing:
                   enabled: true
-                  signType: ${{ parameters.SignType }}
+                  signType: ${{ variables.SignType }}
                   feedSource: 'https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json'
+                  signWithProd: true
               
                 localization:
                   enabled: true


### PR DESCRIPTION
## What/Why
We need to enable PME signing with the new rule enforcement (Real signing with PME Enforcement - June 30th 2025).

## How
1. Enable PME signing with `signWithProd: true`
2. Only allow real signs for the CI pipeline.

## Testing
Verified the stages can be configured in the topic branch (which indicates no errors in the pipeline).