### PR TITLE
Update DisableMCP to 17.14.31+ or 18.7+

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -76,6 +76,12 @@
                     <reference ref="VisualStudio2026"/>
                 </and>
             </definition>
+            <definition name="VisualStudio2022_14_31_AndHigher" displayName="$(string.VisualStudio2022_14_31_AndHigher)">
+                <and>
+                    <reference ref="VisualStudio2022_14_31"/>
+                    <reference ref="VisualStudio2026"/>
+                </and>
+            </definition>
             <definition name="VisualStudio2026AndHigher" displayName="$(string.VisualStudio2026AndHigher)">
                 <and>
                     <reference ref="VisualStudio2026"/>
@@ -692,7 +698,7 @@
             key="SOFTWARE\Policies\Microsoft\VisualStudio\Copilot"
             valueName="DisableMCP">
             <parentCategory ref="CopilotSettings" />
-            <supportedOn ref="VisualStudio2022AndHigher" />
+            <supportedOn ref="VisualStudio2022_14_31_AndHigher" />
             <enabledValue>
                 <decimal value="1" />
             </enabledValue>

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -20,6 +20,7 @@
                     <minorVersion name="VisualStudio2022_12" displayName="$(string.VisualStudioProductName2022_12)" versionIndex="12"/>
                     <minorVersion name="VisualStudio2022_13" displayName="$(string.VisualStudioProductName2022_13)" versionIndex="13"/>
                     <minorVersion name="VisualStudio2022_14_16" displayName="$(string.VisualStudioProductName2022_14_16)" versionIndex="1416"/>
+                    <minorVersion name="VisualStudio2022_14_31" displayName="$(string.VisualStudioProductName2022_14_31)" versionIndex="1431"/>
                 </majorVersion>
                 <majorVersion name="VisualStudio2026" displayName="$(string.VisualStudioProductName2026)" versionIndex="18" />
             </product>
@@ -52,6 +53,7 @@
                     <reference ref="VisualStudio2022_12"/>
                     <reference ref="VisualStudio2022_13"/>
                     <reference ref="VisualStudio2022_14_16"/>
+                    <reference ref="VisualStudio2022_14_31"/>
                     <reference ref="VisualStudio2026"/>
                 </and>
             </definition>
@@ -60,6 +62,7 @@
                     <reference ref="VisualStudio2022_12"/>
                     <reference ref="VisualStudio2022_13"/>
                     <reference ref="VisualStudio2022_14_16"/>
+                    <reference ref="VisualStudio2022_14_31"/>
                     <reference ref="VisualStudio2026"/>
                 </and>
             </definition>
@@ -67,12 +70,14 @@
                 <and>
                     <reference ref="VisualStudio2022_13"/>
                     <reference ref="VisualStudio2022_14_16"/>
+                    <reference ref="VisualStudio2022_14_31"/>
                     <reference ref="VisualStudio2026"/>
                 </and>
             </definition>
             <definition name="VisualStudio2022_14_16_AndHigher" displayName="$(string.VisualStudio2022_14_16_AndHigher)">
                 <and>
                     <reference ref="VisualStudio2022_14_16"/>
+                    <reference ref="VisualStudio2022_14_31"/>
                     <reference ref="VisualStudio2026"/>
                 </and>
             </definition>

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -22,7 +22,9 @@
                     <minorVersion name="VisualStudio2022_14_16" displayName="$(string.VisualStudioProductName2022_14_16)" versionIndex="1416"/>
                     <minorVersion name="VisualStudio2022_14_31" displayName="$(string.VisualStudioProductName2022_14_31)" versionIndex="1431"/>
                 </majorVersion>
-                <majorVersion name="VisualStudio2026" displayName="$(string.VisualStudioProductName2026)" versionIndex="18" />
+                <majorVersion name="VisualStudio2026" displayName="$(string.VisualStudioProductName2026)" versionIndex="18">
+                    <minorVersion name="VisualStudio2026_7" displayName="$(string.VisualStudioProductName2026_7)" versionIndex="7"/>
+                </majorVersion>
             </product>
         </products>
         <definitions>
@@ -81,15 +83,15 @@
                     <reference ref="VisualStudio2026"/>
                 </and>
             </definition>
-            <definition name="VisualStudio2022_14_31_AndHigher" displayName="$(string.VisualStudio2022_14_31_AndHigher)">
-                <and>
-                    <reference ref="VisualStudio2022_14_31"/>
-                    <reference ref="VisualStudio2026"/>
-                </and>
-            </definition>
             <definition name="VisualStudio2026AndHigher" displayName="$(string.VisualStudio2026AndHigher)">
                 <and>
                     <reference ref="VisualStudio2026"/>
+                </and>
+            </definition>
+            <definition name="VisualStudio2022_14_31AndHigher_Or_2026_7AndHigher" displayName="$(string.VisualStudio2022_14_31AndHigher_Or_2026_7AndHigher)">
+                <and>
+                    <reference ref="VisualStudio2022_14_31"/>
+                    <reference ref="VisualStudio2026_7"/>
                 </and>
             </definition>
         </definitions>
@@ -703,7 +705,7 @@
             key="SOFTWARE\Policies\Microsoft\VisualStudio\Copilot"
             valueName="DisableMCP">
             <parentCategory ref="CopilotSettings" />
-            <supportedOn ref="VisualStudio2022_14_31_AndHigher" />
+            <supportedOn ref="VisualStudio2022_14_31AndHigher_Or_2026_7AndHigher" />
             <enabledValue>
                 <decimal value="1" />
             </enabledValue>

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -684,5 +684,21 @@
                 <decimal value="0" />
             </disabledValue>
         </policy>
+        <policy
+            name="DisableMCP"
+            class="Machine"
+            displayName="$(string.DisableMCP_DisplayName)"
+            explainText="$(string.DisableMCP_Explain)"
+            key="SOFTWARE\Policies\Microsoft\VisualStudio\Copilot"
+            valueName="DisableMCP">
+            <parentCategory ref="CopilotSettings" />
+            <supportedOn ref="VisualStudio2022AndHigher" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
     </policies>
 </policyDefinitions>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -23,6 +23,7 @@
       <string id="VisualStudioProductName2019">Visual Studio 2019</string>
       <string id="VisualStudioProductName2022">Visual Studio 2022</string>
       <string id="VisualStudioProductName2026">Visual Studio 2026</string>
+      <string id="VisualStudioProductName2026_7">Visual Studio 2026, 18.7</string>
 
       <!-- The VS catalog minor versions. -->
       <string id="VisualStudioProductName2022_1">Visual Studio 2022, 17.1</string>
@@ -43,8 +44,8 @@
       <string id="VisualStudio2022_12AndHigher">Visual Studio 2022, 17.12 and higher.</string>
       <string id="VisualStudio2022_13AndHigher">Visual Studio 2022, 17.13 and higher.</string>
       <string id="VisualStudio2022_14_16_AndHigher">Visual Studio 2022, 17.14.16 and higher.</string>
-      <string id="VisualStudio2022_14_31_AndHigher">Visual Studio 2022, 17.14.31 and higher.</string>
       <string id="VisualStudio2026AndHigher">Visual Studio 2026 and higher.</string>
+      <string id="VisualStudio2022_14_31AndHigher_Or_2026_7AndHigher">Visual Studio 2022, 17.14.31 and higher; Visual Studio 2026, 18.7 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->
       <string id="VisualStudio2022_Enterprise_Professional">At least Visual Studio 2022, Enterprise and Professional only</string>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -42,6 +42,7 @@
       <string id="VisualStudio2022_12AndHigher">Visual Studio 2022, 17.12 and higher.</string>
       <string id="VisualStudio2022_13AndHigher">Visual Studio 2022, 17.13 and higher.</string>
       <string id="VisualStudio2022_14_16_AndHigher">Visual Studio 2022, 17.14.16 and higher.</string>
+      <string id="VisualStudio2022_14_31_AndHigher">Visual Studio 2022, 17.14.31 and higher.</string>
       <string id="VisualStudio2026AndHigher">Visual Studio 2026 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->
@@ -216,7 +217,7 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <string id="DisableAgentMode_DisplayName">Disable Agent Mode</string>
       <string id="DisableAgentMode_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Agent mode. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableMCP_DisplayName">Disable Model Context Protocol (MCP)</string>
-      <string id="DisableMCP_Explain">If this setting is enabled, it will prevent your users from using MCP for GitHub Copilot.</string>
+      <string id="DisableMCP_Explain">If this setting is enabled, it will prevent your users from using MCP for GitHub Copilot. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
 
     </stringTable>
     <presentationTable>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -31,6 +31,7 @@
       <string id="VisualStudioProductName2022_12">Visual Studio 2022, 17.12</string>
       <string id="VisualStudioProductName2022_13">Visual Studio 2022, 17.13</string>
       <string id="VisualStudioProductName2022_14_16">Visual Studio 2022, 17.14.16</string>
+      <string id="VisualStudioProductName2022_14_31">Visual Studio 2022, 17.14.31</string>
 
       <!-- Convey a particular version and higher. -->
       <string id="VisualStudio2017AndHigher">Visual Studio 2017 and higher.</string>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -215,6 +215,8 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <string id="DisableCopilotForIndividuals_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot for Individual. GitHub Copilot for Business and GitHub Copilot for Enterprise will still be enabled. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableAgentMode_DisplayName">Disable Agent Mode</string>
       <string id="DisableAgentMode_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Agent mode. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
+      <string id="DisableMCP_DisplayName">Disable Model Context Protocol (MCP)</string>
+      <string id="DisableMCP_Explain">If this setting is enabled, it will prevent your users from using MCP for GitHub Copilot.</string>
 
     </stringTable>
     <presentationTable>


### PR DESCRIPTION
Visual Studio will not be backporting the change to include group policy for versions [18.0, 18.6]. We will backport to 17.14.31 however. The templates have been updated to indicate by with `VisualStudio2022_14_31AndHigher_Or_2026_7AndHigher`

<img width="1515" height="915" alt="image" src="https://github.com/user-attachments/assets/9b300e51-b113-4a44-92aa-092773846394" />
