### PR TITLE
Add ExtensionGalleryServiceUrl policy for private marketplace enforcement

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -116,6 +116,9 @@
         <category name="CopilotSettings" displayName="$(string.CopilotCategoryName)">
             <parentCategory ref="VisualStudio"/>
         </category>
+        <category name="ExtensionSettings" displayName="$(string.ExtensionSettingsCategoryName)">
+            <parentCategory ref="VisualStudio"/>
+        </category>
     </categories>
     <policies>
         
@@ -712,6 +715,20 @@
             <disabledValue>
                 <decimal value="0" />
             </disabledValue>
+        </policy>
+        <!-- Extension Settings -->
+        <policy
+            name="ExtensionGalleryServiceUrl"
+            class="Machine"
+            displayName="$(string.ExtensionGalleryServiceUrl_DisplayName)"
+            explainText="$(string.ExtensionGalleryServiceUrl_Explain)"
+            presentation="$(presentation.ExtensionGalleryServiceUrl_PresentationId)"
+            key="SOFTWARE\Policies\Microsoft\VisualStudio\Governance\Extensions">
+            <parentCategory ref="ExtensionSettings" />
+            <supportedOn ref="VisualStudio2026AndHigher" />
+            <elements>
+                <text id="ExtensionGalleryServiceUrl_TextBox" valueName="ExtensionGalleryServiceUrl" />
+            </elements>
         </policy>
     </policies>
 </policyDefinitions>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -17,6 +17,7 @@
       <string id="PrivacySettingsCategoryName">Privacy Settings</string>
       <string id="VisualStudioDevTunnels">Dev Tunnel Settings</string>
       <string id="CopilotCategoryName">Copilot Settings</string>
+      <string id="ExtensionSettingsCategoryName">Extension Settings</string>
 
       <!-- The VS catalog Product Names. -->
       <string id="VisualStudioProductName2017">Visual Studio 2017</string>
@@ -222,6 +223,14 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <string id="DisableMCP_DisplayName">Disable Model Context Protocol (MCP)</string>
       <string id="DisableMCP_Explain">If this setting is enabled, it will prevent your users from using MCP for GitHub Copilot. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
 
+      <!-- Extensions -->
+      <string id="ExtensionGalleryServiceUrl_DisplayName">Set the extension gallery service URL</string>
+      <string id="ExtensionGalleryServiceUrl_Explain">This policy sets the URL of the extension gallery service that Visual Studio uses to browse and install extensions. Use this to enforce that users obtain extensions from a private marketplace instead of the public Visual Studio Marketplace.
+
+When enabled, Visual Studio will use the specified URL as the extension gallery service endpoint.
+
+When disabled or not configured, Visual Studio will use the default public Visual Studio Marketplace.</string>
+
     </stringTable>
     <presentationTable>
       <presentation id="AdministratorUpdatesEnabled_PresentationId">
@@ -256,6 +265,12 @@ For more information, see: https://aka.ms/vsls-policies</string>
         <label>Enter Domain Name:</label>
         </textBox>
     </presentation>
+      <!-- Extension Settings Presentations -->
+      <presentation id="ExtensionGalleryServiceUrl_PresentationId">
+        <textBox refId="ExtensionGalleryServiceUrl_TextBox">
+          <label>Extension Gallery Service URL</label>
+        </textBox>
+      </presentation>
     </presentationTable>
 </resources>
 </policyDefinitionResources>


### PR DESCRIPTION
Adds a new Group Policy under Extension Settings that allows administrators to specify a custom extension gallery service URL, enforcing VS 2026+ users to obtain extensions from a private marketplace instead of the public Visual Studio Marketplace.

Registry path: HKLM\SOFTWARE\Policies\Microsoft\VisualStudio\Governance\Extensions\ExtensionGalleryServiceUrl
Supported on: Visual Studio 2026 and higher