### PR TITLE
Add InformationDisabled feedback Group Policy

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -183,6 +183,22 @@
                 <decimal value="0" />
             </disabledValue>
         </policy>
+        <policy
+            name="InformationDisabled"
+            class="Machine"
+            displayName="$(string.InformationDisabled_DisplayName)"
+            explainText="$(string.InformationDisabled_Explain)"
+            key="Software\Policies\Microsoft\VisualStudio\Feedback"
+            valueName="InformationDisabled">
+            <parentCategory ref="FeedbackSettings" />
+            <supportedOn ref="VisualStudio2026AndHigher" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
 
         <!-- Install and Update Settings -->
         <policy 

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -61,6 +61,8 @@
       <string id="ProductFeedbackDisabled_Explain">This policy disables feedback mechanisms throughout the IDE and installer, i.e. thumbs up or down, the feedback window pop-up, send-a-smile feature, info bars without survey links.</string>
       <string id="SurveysDisabled_DisplayName">Disables external survey links throughout the IDE and installer</string>
       <string id="SurveysDisabled_Explain">This policy disables survey links throughout the IDE and installer, i.e. in the preview feature pane, bulletins, info bars with survey links.</string>
+      <string id="InformationDisabled_DisplayName">Disables informational announcements throughout the IDE and installer</string>
+      <string id="InformationDisabled_Explain">This policy disables informational announcements throughout the IDE and installer, such as general product announcements or notices shown via info bars.</string>
       
       <!-- Install and Update -->
       <string id="RemoveOutOfSupport_DisplayName">Remove out-of-support components during updates</string>


### PR DESCRIPTION
Adds an `InformationDisabled` machine policy to the **Feedback** category so administrators can disable informational announcements shown via info bars, mirroring the existing `SurveysDisabled` policy.

Visual Studio 2026 reads `HKLM\Software\Policies\Microsoft\VisualStudio\Feedback\InformationDisabled` to suppress these info bars. `supportedOn` is `VisualStudio2026AndHigher` because this notification category is new in VS 18. ADML display/explain strings are added for en-US (the only locale maintained in this repo).
