### PR TITLE
Add policy to disable unauthenticated BYOK

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -697,6 +697,23 @@
                 <decimal value="0" />
             </disabledValue>
         </policy>
+        <!-- Bring your own key -->
+        <policy
+            name="DisableBringYourOwnKeyNoAuth"
+            class="Machine"
+            displayName="$(string.DisableBringYourOwnKeyNoAuth_DisplayName)"
+            explainText="$(string.DisableBringYourOwnKeyNoAuth_Explain)"
+            key="SOFTWARE\Policies\Microsoft\VisualStudio\Copilot"
+            valueName="DisableBringYourOwnKeyNoAuth">
+            <parentCategory ref="CopilotSettings" />
+            <supportedOn ref="VisualStudio2022_14_16_AndHigher" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
         <policy
             name="DisableMCP"
             class="Machine"

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -219,6 +219,8 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <string id="DisableCopilotForIndividuals_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot for Individual. GitHub Copilot for Business and GitHub Copilot for Enterprise will still be enabled. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableAgentMode_DisplayName">Disable Agent Mode</string>
       <string id="DisableAgentMode_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Agent mode. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
+      <string id="DisableBringYourOwnKeyNoAuth_DisplayName">Disable Bring Your Own Key (No Auth)</string>
+      <string id="DisableBringYourOwnKeyNoAuth_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Bring Your Own Key (No Auth) feature. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableMCP_DisplayName">Disable Model Context Protocol (MCP)</string>
       <string id="DisableMCP_Explain">If this setting is enabled, it will prevent your users from using MCP for GitHub Copilot. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
 


### PR DESCRIPTION
Add Group policy entries to disable Bring your own key (no github auth required state).