### PR TITLE
Add policy to disable unauthenticated BYOK

### DIFF
--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -24,6 +24,7 @@
                 </majorVersion>
                 <majorVersion name="VisualStudio2026" displayName="$(string.VisualStudioProductName2026)" versionIndex="18">
                     <minorVersion name="VisualStudio2026_7" displayName="$(string.VisualStudioProductName2026_7)" versionIndex="7"/>
+                    <minorVersion name="VisualStudio2026_11" displayName="$(string.VisualStudioProductName2026_11)" versionIndex="11"/>
                 </majorVersion>
             </product>
         </products>
@@ -92,6 +93,11 @@
                 <and>
                     <reference ref="VisualStudio2022_14_31"/>
                     <reference ref="VisualStudio2026_7"/>
+                </and>
+            </definition>
+            <definition name="VisualStudio2026_11AndHigher" displayName="$(string.VisualStudio2026_11AndHigher)">
+                <and>
+                    <reference ref="VisualStudio2026_11"/>
                 </and>
             </definition>
         </definitions>
@@ -697,23 +703,6 @@
                 <decimal value="0" />
             </disabledValue>
         </policy>
-        <!-- Bring your own key -->
-        <policy
-            name="DisableBringYourOwnKeyNoAuth"
-            class="Machine"
-            displayName="$(string.DisableBringYourOwnKeyNoAuth_DisplayName)"
-            explainText="$(string.DisableBringYourOwnKeyNoAuth_Explain)"
-            key="SOFTWARE\Policies\Microsoft\VisualStudio\Copilot"
-            valueName="DisableBringYourOwnKeyNoAuth">
-            <parentCategory ref="CopilotSettings" />
-            <supportedOn ref="VisualStudio2022_14_16_AndHigher" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
         <policy
             name="DisableMCP"
             class="Machine"
@@ -723,6 +712,23 @@
             valueName="DisableMCP">
             <parentCategory ref="CopilotSettings" />
             <supportedOn ref="VisualStudio2022_14_31AndHigher_Or_2026_7AndHigher" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <!-- Bring your own key -->
+        <policy
+            name="DisableBringYourOwnKeyNoAuth"
+            class="Machine"
+            displayName="$(string.DisableBringYourOwnKeyNoAuth_DisplayName)"
+            explainText="$(string.DisableBringYourOwnKeyNoAuth_Explain)"
+            key="SOFTWARE\Policies\Microsoft\VisualStudio\Copilot"
+            valueName="DisableBringYourOwnKeyNoAuth">
+            <parentCategory ref="CopilotSettings" />
+            <supportedOn ref="VisualStudio2026_11AndHigher" />
             <enabledValue>
                 <decimal value="1" />
             </enabledValue>

--- a/settingFiles/admx/VisualStudio.admx
+++ b/settingFiles/admx/VisualStudio.admx
@@ -697,6 +697,23 @@
                 <decimal value="0" />
             </disabledValue>
         </policy>
+        <!-- Bring your own key -->
+        <policy
+            name="DisableBringYourOwnKeyNoAuth"
+            class="Machine"
+            displayName="$(string.DisableBringYourOwnKeyNoAuth_DisplayName)"
+            explainText="$(string.DisableBringYourOwnKeyNoAuth_Explain)"
+            key="SOFTWARE\Policies\Microsoft\VisualStudio\Copilot"
+            valueName="DisableBringYourOwnKeyNoAuth">
+            <parentCategory ref="CopilotSettings" />
+            <supportedOn ref="VisualStudio2022_14_16_AndHigher" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
         <policy
             name="DisableMCP"
             class="Machine"

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -24,6 +24,7 @@
       <string id="VisualStudioProductName2022">Visual Studio 2022</string>
       <string id="VisualStudioProductName2026">Visual Studio 2026</string>
       <string id="VisualStudioProductName2026_7">Visual Studio 2026, 18.7</string>
+      <string id="VisualStudioProductName2026_11">Visual Studio 2026, 18.11</string>
 
       <!-- The VS catalog minor versions. -->
       <string id="VisualStudioProductName2022_1">Visual Studio 2022, 17.1</string>
@@ -47,6 +48,7 @@
       <string id="VisualStudio2022_14_31_AndHigher">Visual Studio 2022, 17.14.31 and higher.</string>
       <string id="VisualStudio2026AndHigher">Visual Studio 2026 and higher.</string>
       <string id="VisualStudio2022_14_31AndHigher_Or_2026_7AndHigher">Visual Studio 2022, 17.14.31 and higher; Visual Studio 2026, 18.7 and higher.</string>
+      <string id="VisualStudio2026_11AndHigher">Visual Studio 2026, 18.11 and higher.</string>
 
       <!-- Convey a particular version and distribution. -->
       <string id="VisualStudio2022_Enterprise_Professional">At least Visual Studio 2022, Enterprise and Professional only</string>
@@ -219,10 +221,10 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <string id="DisableCopilotForIndividuals_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot for Individual. GitHub Copilot for Business and GitHub Copilot for Enterprise will still be enabled. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableAgentMode_DisplayName">Disable Agent Mode</string>
       <string id="DisableAgentMode_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Agent mode. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
-      <string id="DisableBringYourOwnKeyNoAuth_DisplayName">Disable Bring Your Own Key (No Auth)</string>
-      <string id="DisableBringYourOwnKeyNoAuth_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Bring Your Own Key (No Auth) feature. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableMCP_DisplayName">Disable Model Context Protocol (MCP)</string>
       <string id="DisableMCP_Explain">If this setting is enabled, it will prevent your users from using MCP for GitHub Copilot. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
+      <string id="DisableBringYourOwnKeyNoAuth_DisplayName">Disable Bring Your Own Key (No Auth)</string>
+      <string id="DisableBringYourOwnKeyNoAuth_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Bring Your Own Key (No Auth) feature. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
 
     </stringTable>
     <presentationTable>

--- a/settingFiles/admx/en-US/VisualStudio.adml
+++ b/settingFiles/admx/en-US/VisualStudio.adml
@@ -219,6 +219,8 @@ For more information, see: https://aka.ms/vsls-policies</string>
       <string id="DisableCopilotForIndividuals_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot for Individual. GitHub Copilot for Business and GitHub Copilot for Enterprise will still be enabled. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableAgentMode_DisplayName">Disable Agent Mode</string>
       <string id="DisableAgentMode_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Agent mode. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
+      <string id="DisableBringYourOwnKeyNoAuth_DisplayName">Disable Bring Your Own Key (No Auth)</string>
+      <string id="DisableBringYourOwnKeyNoAuth_Explain">If this setting is enabled, it will prevent your users from using GitHub Copilot's Bring Your Own Key (No Auth) feature. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
       <string id="DisableMCP_DisplayName">Disable Model Context Protocol (MCP)</string>
       <string id="DisableMCP_Explain">If this setting is enabled, it will prevent your users from using MCP for GitHub Copilot. For more information, see: https://aka.ms/CopilotGroupPolicy</string>
 


### PR DESCRIPTION
Add ADMX policies for disabling un-authenticated bring your own key. 

Validated:
Shows up in group policy  editor
UnSet, Enable, Disabled are correctly read in
Feature is enabled or disabled correctly based on those settings.